### PR TITLE
Release 1.2.1 with reliable Power Mac CD startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.2.1 — 2026-07-10
+
+### Fixed
+
+- **The Mac OS 9.2.1 install CD no longer stops at an Apple Audio Extension
+  address error.** The failure requires a loaded second Tools CD and Sungem
+  networking at the same time; either device alone boots normally. Networked
+  Power Mac CD boots now leave the dedicated Tools tray empty at startup while
+  keeping the drive available for manual insertion from the Machine menu after
+  Finder appears.
+- **Turning networking off now removes the emulated NIC.** QEMU creates each
+  machine's default network adapter when no `-nic` option is supplied, so the
+  old off path silently left networking enabled. ClassicMac now passes
+  `-nic none` explicitly.
+
 ## 1.2.0 — 2026-07-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
   machine's default network adapter when no `-nic` option is supplied, so the
   old off path silently left networking enabled. ClassicMac now passes
   `-nic none` explicitly.
+- **Power Mac tablet input now stays seamless while booting installer CDs.**
+  The CD path used to ignore the enabled tablet setting, omit the classicvirtio
+  driver loader, and fall back to a relative USB mouse that captured the host
+  pointer. The loader installs the tablet NDRV and then resumes Open Firmware's
+  selected boot device, so it can safely remain active while `-boot d` starts
+  Mac OS 9.2.1 or 9.2.2 from CD.
 
 ## 1.2.0 — 2026-07-10
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ ClassicMac exists because of years of brilliant work by other engineers. The pat
 > regular installation. ClassicMac's QEMU build fixes the MacIO IDE/DBDMA
 > completion race that made some 9.2.1 and 9.2.2 installers freeze around
 > "About 4 minutes remaining," so a frozen partial System Folder is no longer
-> expected or considered a successful install.
+> expected or considered a successful install. During a Power Mac CD boot, the
+> Tools CD starts with an empty tray when networking is enabled to avoid a Mac
+> OS 9.2.1 startup crash; after Finder appears, insert it from the QEMU
+> **Machine** menu if needed.
 
 New machines are created as `.classic` documents (default `~/Documents/ClassicMac/`). Double-click one in Finder to boot it.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -11,8 +11,8 @@ QEMU emulator as a whole is licensed under the GNU General Public License,
 version 2. Individual source and firmware files may carry compatible licenses,
 as described by QEMU's `LICENSE` file and their source headers.
 
-The exact corresponding source is reproducible from the ClassicMac 1.2.0
-source at <https://github.com/amcchord/ClassicMac/tree/v1.2.0>. The repository's
+The exact corresponding source is reproducible from the ClassicMac 1.2.1
+source at <https://github.com/amcchord/ClassicMac/tree/v1.2.1>. The repository's
 `scripts/build-qemu.sh` retrieves the pinned upstream QEMU 11.0.2 source and
 applies every ClassicMac modification stored in the repository.
 

--- a/app/Package.swift
+++ b/app/Package.swift
@@ -15,6 +15,11 @@ let package = Package(
                 // language mode until the concurrency audit is done.
                 .swiftLanguageMode(.v5)
             ]
+        ),
+        .testTarget(
+            name: "ClassicMacTests",
+            dependencies: ["ClassicMac"],
+            path: "Tests/ClassicMacTests"
         )
     ]
 )

--- a/app/Sources/ClassicMac/QEMURunner.swift
+++ b/app/Sources/ClassicMac/QEMURunner.swift
@@ -367,9 +367,13 @@ final class QEMUManager: ObservableObject {
     // The dedicated Tools CD drive (id=tools0). Starts loaded with the
     // bundled ClassicMac Tools image when the VM's settings ask for it,
     // otherwise as an empty tray the Machine menu can fill at runtime.
-    private static func toolsDriveSpec(for config: VMConfig, iface: String) -> String {
+    private static func toolsDriveSpec(
+        for config: VMConfig,
+        iface: String,
+        loadMedia: Bool = true
+    ) -> String {
         var spec = "if=\(iface),media=cdrom,id=tools0"
-        if config.toolsCDInserted, let toolsCD = AppPaths.toolsCD {
+        if loadMedia, config.toolsCDInserted, let toolsCD = AppPaths.toolsCD {
             spec += ",file=\(toolsCD.path),format=raw"
         }
         return spec
@@ -390,8 +394,10 @@ final class QEMUManager: ObservableObject {
         // driver). The loader takes over the firmware boot command, so it is
         // skipped when booting from CD (e.g. OS installs) - sharing and tablet
         // input are simply inactive for that boot.
-        let sharing = config.hasSharedFolder && !(config.bootFromCD && config.cdImagePath?.isEmpty == false)
-        let tablet = config.tabletInput && !(config.bootFromCD && config.cdImagePath?.isEmpty == false)
+        let bootingFromUserCD = config.bootFromCD && config.cdImagePath?.isEmpty == false
+        let deferToolsMedia = bootingFromUserCD && config.networking
+        let sharing = config.hasSharedFolder && !bootingFromUserCD
+        let tablet = config.tabletInput && !bootingFromUserCD
         let needsNdrvLoader = sharing || tablet
 
         // Input configuration. QEMU treats whichever pointing device the guest
@@ -488,14 +494,23 @@ final class QEMUManager: ObservableObject {
         // Dedicated second CD drive for the ClassicMac Tools CD. Always
         // present so the QEMU window's Machine menu can insert/eject the
         // Tools CD while the Mac is running; loaded at boot when the VM's
-        // settings say so. It comes after the user's disc on the IDE chain,
-        // so "-boot d" still starts up from the user's (bootable) CD even
-        // with both inserted.
-        args += ["-drive", toolsDriveSpec(for: config, iface: "ide")]
+        // settings say so. Keep its tray empty while starting a networked
+        // Power Mac from another CD: Mac OS 9.2.1's startup is unstable when
+        // it mounts a second CD alongside the installer and initializes
+        // Sungem. The empty drive remains available, so the Machine menu can
+        // insert the Tools image after Finder appears. With networking off,
+        // the requested Tools media is safe to load normally.
+        args += [
+            "-drive",
+            toolsDriveSpec(for: config, iface: "ide", loadMedia: !deferToolsMedia)
+        ]
 
         // User-mode networking through the mac99 onboard sungem ethernet.
         if config.networking {
             args += ["-nic", "user,model=sungem"]
+        } else {
+            // QEMU otherwise creates the mac99 machine's default Sungem NIC.
+            args += ["-nic", "none"]
         }
 
         // Shared folder via virtio-9p-pci and the classicvirtio ndrvloader.
@@ -604,6 +619,9 @@ final class QEMUManager: ObservableObject {
         // so networking is configured with -nic (not a separate -device).
         if config.networking {
             args += ["-nic", "user,model=dp83932"]
+        } else {
+            // QEMU otherwise creates the q800 machine's default NIC.
+            args += ["-nic", "none"]
         }
 
         // Shared folder via the classicvirtio NuBus virtio transport. The

--- a/app/Sources/ClassicMac/QEMURunner.swift
+++ b/app/Sources/ClassicMac/QEMURunner.swift
@@ -390,14 +390,14 @@ final class QEMUManager: ObservableObject {
 
         // Folder sharing needs the classicvirtio ndrvloader to run before the
         // OS: it installs the virtio NDRVs and then continues the normal boot.
-        // Tablet input also needs the ndrvloader (it loads the virtio-tablet
-        // driver). The loader takes over the firmware boot command, so it is
-        // skipped when booting from CD (e.g. OS installs) - sharing and tablet
-        // input are simply inactive for that boot.
+        // Sharing stays inactive while booting an installer CD so the install
+        // environment never sees the host folder. Tablet input uses the same
+        // loader, but remains enabled: after injecting its NDRV the loader runs
+        // Open Firmware's normal `boot` command, which still honors `-boot d`.
         let bootingFromUserCD = config.bootFromCD && config.cdImagePath?.isEmpty == false
         let deferToolsMedia = bootingFromUserCD && config.networking
         let sharing = config.hasSharedFolder && !bootingFromUserCD
-        let tablet = config.tabletInput && !bootingFromUserCD
+        let tablet = config.tabletInput
         let needsNdrvLoader = sharing || tablet
 
         // Input configuration. QEMU treats whichever pointing device the guest

--- a/app/Sources/ClassicMac/VMDetailView.swift
+++ b/app/Sources/ClassicMac/VMDetailView.swift
@@ -413,9 +413,18 @@ struct VMDetailView: View {
                 Toggle(isOn: vm.toolsCDInserted) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Tools CD")
-                        Text("Guest essentials in a second CD drive: StuffIt Expander, Disk Copy, a CD image mounter, and (Power Mac) the USB Overdrive scroll wheel driver. Can be inserted alongside a bootable disc, or from the Machine menu while the Mac is running.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                        if vm.wrappedValue.machineFamily == .powerMacG4 &&
+                            vm.wrappedValue.bootFromCD &&
+                            vm.wrappedValue.cdImagePath?.isEmpty == false &&
+                            vm.wrappedValue.networking {
+                            Text("With networking enabled, the Tools tray starts empty during a Power Mac CD boot for Mac OS 9 compatibility. After the desktop appears, insert it from the Machine menu.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Text("Guest essentials in a second CD drive: StuffIt Expander, Disk Copy, a CD image mounter, and (Power Mac) the USB Overdrive scroll wheel driver. Can also be inserted from the Machine menu while the Mac is running.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                 }
                 .disabled(running)

--- a/app/Tests/ClassicMacTests/QEMURunnerArgumentTests.swift
+++ b/app/Tests/ClassicMacTests/QEMURunnerArgumentTests.swift
@@ -8,7 +8,9 @@ final class QEMURunnerArgumentTests: XCTestCase {
         family: MachineFamily = .powerMacG4,
         bootFromCD: Bool = true,
         toolsCDInserted: Bool = true,
-        networking: Bool = true
+        networking: Bool = true,
+        tabletInput: Bool = true,
+        sharedFolderPath: String? = nil
     ) -> VMConfig {
         VMConfig(
             name: "Argument Test",
@@ -19,7 +21,8 @@ final class QEMURunnerArgumentTests: XCTestCase {
             toolsCDInserted: toolsCDInserted,
             networking: networking,
             sound: false,
-            tabletInput: false,
+            tabletInput: tabletInput,
+            sharedFolderPath: sharedFolderPath,
             bundleURL: URL(fileURLWithPath: "/tmp/argument-test.classic")
         )
     }
@@ -106,5 +109,75 @@ final class QEMURunnerArgumentTests: XCTestCase {
 
         XCTAssertEqual(optionValues("-nic", in: powerMacArguments), ["none"])
         XCTAssertEqual(optionValues("-nic", in: quadraArguments), ["none"])
+    }
+
+    func testPowerMacCDStartupKeepsTabletInputEnabled() {
+        let arguments = QEMUManager.buildArguments(
+            for: config(tabletInput: true)
+        )
+        let devices = optionValues("-device", in: arguments)
+
+        XCTAssertEqual(
+            optionValues("-M", in: arguments),
+            ["mac99,via=pmu-adb,audiodev=snd0"]
+        )
+        XCTAssertEqual(optionValues("-boot", in: arguments), ["d"])
+        XCTAssertTrue(devices.contains("virtio-tablet-pci"))
+        XCTAssertTrue(
+            devices.contains { $0.hasPrefix("loader,addr=0x4000000,file=") }
+        )
+        XCTAssertTrue(
+            optionValues("-prom-env", in: arguments)
+                .contains("boot-command=init-program go")
+        )
+    }
+
+    func testPowerMacCDStartupSuppressesSharingButKeepsTabletInput() {
+        let arguments = QEMUManager.buildArguments(
+            for: config(
+                tabletInput: true,
+                sharedFolderPath: "/tmp/shared-folder"
+            )
+        )
+        let devices = optionValues("-device", in: arguments)
+
+        XCTAssertTrue(devices.contains("virtio-tablet-pci"))
+        XCTAssertFalse(devices.contains { $0.hasPrefix("virtio-9p-pci,") })
+        XCTAssertTrue(optionValues("-fsdev", in: arguments).isEmpty)
+    }
+
+    func testPowerMacCDStartupWithoutTabletUsesRelativeMouse() {
+        let arguments = QEMUManager.buildArguments(
+            for: config(tabletInput: false)
+        )
+        let devices = optionValues("-device", in: arguments)
+
+        XCTAssertEqual(
+            optionValues("-M", in: arguments),
+            ["mac99,via=pmu,audiodev=snd0"]
+        )
+        XCTAssertFalse(devices.contains("virtio-tablet-pci"))
+        XCTAssertFalse(
+            devices.contains { $0.hasPrefix("loader,addr=0x4000000,file=") }
+        )
+        XCTAssertFalse(
+            optionValues("-prom-env", in: arguments)
+                .contains("boot-command=init-program go")
+        )
+    }
+
+    func testPowerMacNormalStartupKeepsTabletInputEnabled() {
+        let arguments = QEMUManager.buildArguments(
+            for: config(bootFromCD: false, tabletInput: true)
+        )
+
+        XCTAssertEqual(
+            optionValues("-M", in: arguments),
+            ["mac99,via=pmu-adb,audiodev=snd0"]
+        )
+        XCTAssertTrue(
+            optionValues("-device", in: arguments)
+                .contains("virtio-tablet-pci")
+        )
     }
 }

--- a/app/Tests/ClassicMacTests/QEMURunnerArgumentTests.swift
+++ b/app/Tests/ClassicMacTests/QEMURunnerArgumentTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+import Darwin
+@testable import ClassicMac
+
+@MainActor
+final class QEMURunnerArgumentTests: XCTestCase {
+    private func config(
+        family: MachineFamily = .powerMacG4,
+        bootFromCD: Bool = true,
+        toolsCDInserted: Bool = true,
+        networking: Bool = true
+    ) -> VMConfig {
+        VMConfig(
+            name: "Argument Test",
+            machineFamily: family,
+            ramMB: family.defaultRAMMB,
+            cdImagePath: "/tmp/install.iso",
+            bootFromCD: bootFromCD,
+            toolsCDInserted: toolsCDInserted,
+            networking: networking,
+            sound: false,
+            tabletInput: false,
+            bundleURL: URL(fileURLWithPath: "/tmp/argument-test.classic")
+        )
+    }
+
+    private func optionValues(_ option: String, in arguments: [String]) -> [String] {
+        arguments.indices.compactMap { index in
+            guard arguments[index] == option, arguments.indices.contains(index + 1) else {
+                return nil
+            }
+            return arguments[index + 1]
+        }
+    }
+
+    private func withTemporaryToolsCD<T>(_ body: () throws -> T) throws -> T {
+        let key = "CLASSICMAC_REPO"
+        let previous = ProcessInfo.processInfo.environment[key]
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let dist = root.appendingPathComponent("dist", isDirectory: true)
+        let toolsCD = dist.appendingPathComponent("ClassicMacTools.iso")
+
+        try FileManager.default.createDirectory(
+            at: dist,
+            withIntermediateDirectories: true
+        )
+        try Data().write(to: toolsCD)
+        setenv(key, root.path, 1)
+        defer {
+            if let previous {
+                setenv(key, previous, 1)
+            } else {
+                unsetenv(key)
+            }
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        return try body()
+    }
+
+    func testPowerMacCDStartupKeepsToolsTrayEmpty() throws {
+        try withTemporaryToolsCD {
+            let arguments = QEMUManager.buildArguments(for: config())
+            let toolsDrive = optionValues("-drive", in: arguments)
+                .first { $0.contains("id=tools0") }
+
+            XCTAssertEqual(toolsDrive, "if=ide,media=cdrom,id=tools0")
+            XCTAssertTrue(optionValues("-nic", in: arguments).contains("user,model=sungem"))
+        }
+    }
+
+    func testPowerMacNormalStartupLoadsRequestedToolsCD() throws {
+        try withTemporaryToolsCD {
+            let arguments = QEMUManager.buildArguments(for: config(bootFromCD: false))
+            let toolsDrive = try XCTUnwrap(
+                optionValues("-drive", in: arguments).first { $0.contains("id=tools0") }
+            )
+
+            XCTAssertTrue(toolsDrive.contains("file="))
+            XCTAssertTrue(toolsDrive.hasSuffix(",format=raw"))
+        }
+    }
+
+    func testPowerMacCDStartupCanLoadToolsWhenNetworkingIsOff() throws {
+        try withTemporaryToolsCD {
+            let arguments = QEMUManager.buildArguments(
+                for: config(networking: false)
+            )
+            let toolsDrive = try XCTUnwrap(
+                optionValues("-drive", in: arguments).first { $0.contains("id=tools0") }
+            )
+
+            XCTAssertTrue(toolsDrive.contains("file="))
+            XCTAssertEqual(optionValues("-nic", in: arguments), ["none"])
+        }
+    }
+
+    func testNetworkingOffExplicitlyDisablesDefaultNICs() {
+        let powerMacArguments = QEMUManager.buildArguments(
+            for: config(networking: false)
+        )
+        let quadraArguments = QEMUManager.buildArguments(
+            for: config(family: .quadra800, networking: false)
+        )
+
+        XCTAssertEqual(optionValues("-nic", in: powerMacArguments), ["none"])
+        XCTAssertEqual(optionValues("-nic", in: quadraArguments), ["none"])
+    }
+}

--- a/scripts/bundle-qemu.sh
+++ b/scripts/bundle-qemu.sh
@@ -38,7 +38,7 @@ HELPERS_DIR="$CONTENTS/Helpers"
 QUADRA_APP="$HELPERS_DIR/Quadra 800.app"
 PPC_APP="$HELPERS_DIR/Power Mac G4.app"
 
-APP_VERSION="${APP_VERSION:-1.2.0}"
+APP_VERSION="${APP_VERSION:-1.2.1}"
 BUNDLE_ID="com.classicmac.emulator"
 
 log() { printf '\n==> %s\n' "$*"; }


### PR DESCRIPTION
## What changed

- Keep the Power Mac G4 Tools CD tray empty during networked installer-CD startup, while retaining runtime insertion.
- Pass `-nic none` when networking is disabled so QEMU does not create its default Sungem adapter.
- Keep classicvirtio tablet input active during Power Mac installer-CD boots and continue suppressing only host-folder sharing.
- Add focused QEMU argument regressions and document the 1.2.1 fixes.

## Why

Mac OS 9.2.1 can crash in Apple Audio Extension when the installer CD, a loaded Tools CD, and Sungem networking initialize together. Separately, the CD path ignored an enabled tablet setting and forced a relative USB mouse, causing pointer capture.

The classicvirtio loader installs the tablet NDRV and then resumes Open Firmware's selected boot device, so it safely preserves `-boot d`.

## Validation

- All 8 Swift argument tests pass.
- Mac OS 9.2.1 and 9.2.2 installer CDs both reach Finder with default networking.
- Cocoa transitions automatically from the captured ADB fallback to the active absolute virtio tablet, without Control-Option-G, and remains absolute after 30 seconds.
- Tablet-off remains relative/captured as a negative control.
- Installed Mac OS 9.2.1 remains absolute with networking, Tools CD, folder sharing, and after relaunch.
- The 1.2.1 app and DMG are Developer ID signed, Apple-notarized, stapled, and Gatekeeper-approved.