### PR TITLE
Release 1.3.0 with borderless windows and true fullscreen sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.3.0 — 2026-07-10
+
+### Added
+
+- **Borderless machine windows.** Choose View → Hide Title Bar or press
+  Control-Option-T to remove the title, traffic-light controls, and titlebar
+  separator for a clean guest-only window. The command becomes Show Title Bar
+  while active and is also available from the machine's Dock menu.
+
+### Fixed
+
+- **Fullscreen now uses the complete drawable resolution.** The Cocoa display
+  previously subtracted the screen's safe-area inset and could request a guest
+  mode one titlebar-height shorter than the actual fullscreen content. It now
+  reports the final content frame after the transition, opts the machine helper
+  out of camera-housing compatibility mode, and leaves fullscreen sizing to
+  AppKit.
+
 ## 1.2.1 — 2026-07-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ ClassicMac exists because of years of brilliant work by other engineers. The pat
 - **Classic input helpers.** Right-click opens contextual menus as Control+click, and the scroll wheel becomes arrow-key taps — both per-VM toggles for guests with real drivers (e.g. USB Overdrive).
 - **A guest-additions Tools CD** (StuffIt Expander, Disk Copy, USB Overdrive, Transmit, Lido, patched HD SC Setup...) built from `guestcd/manifest.tsv`, insertable at runtime from the machine window's menu — everything pre-expanded and ready to run.
 - **Native machine control.** Pause / Resume, Restart, and Power Off from the app via QEMU's monitor socket, live screen previews in the library, and a "Match Display" button that sizes the Mac to your screen.
-- **Machine window shortcuts that always work.** Control-Option-F toggles fullscreen and Control-Option-R re-pushes the window's resolution to the guest — both keep working even while the emulator has grabbed the keyboard (as fullscreen does), and both live in the View menu and the machine's Dock icon menu.
+- **Machine window shortcuts that always work.** Control-Option-T hides or restores the title bar for a clean borderless look, Control-Option-F toggles fullscreen, and Control-Option-R re-pushes the window's resolution to the guest. All three keep working even while the emulator has grabbed the keyboard, and they also live in the View menu and the machine's Dock icon menu.
 - **Signed, notarized, stapled DMG** for distribution — recipients get a clean Gatekeeper experience even offline.
 
 ## Getting started
@@ -94,6 +94,7 @@ Requirements: an Apple Silicon Mac (M1 or later) running a recent macOS.
 - The resolution you pick is the *boot* resolution and the depth is the *deepest available* mode; classic Mac OS chooses the active depth at startup (a fresh system comes up in B&W until you pick Thousands/Millions once in Monitors — it's remembered per machine).
 - Live resolution switching relies on the Display Manager, so it needs Mac OS ~7.6+ on the Quadra; on the Power Mac it works throughout Mac OS 9. Older systems still boot fine at the configured resolution and scale to the window. Power Mac widths snap down to a multiple of 8 (a VGA hardware constraint).
 - If the guest ever misses a resolution change (the window resized but the Mac stayed at the old size), pick **View → Resend Screen Resolution** (Control-Option-R) — also available from the machine's Dock icon menu — to ask it again.
+- For a borderless machine window, choose **View → Hide Title Bar** or press **Control-Option-T**. Use the same shortcut (or **Show Title Bar**) to restore the normal window controls.
 - To leave fullscreen press **Control-Option-F** (it also enters it). The combo works even while the emulator has grabbed the keyboard; it's listed in the View menu and the Dock icon menu.
 - The Power Mac's packed low-bpp patch adds Black & White, 4 and 16 colors to the Monitors panel alongside 256/thousands/millions.
 - Mac OS 9 wants **less than 1 GB of RAM** for stable sound, so the app's presets stop at 896 MB.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -11,8 +11,8 @@ QEMU emulator as a whole is licensed under the GNU General Public License,
 version 2. Individual source and firmware files may carry compatible licenses,
 as described by QEMU's `LICENSE` file and their source headers.
 
-The exact corresponding source is reproducible from the ClassicMac 1.2.1
-source at <https://github.com/amcchord/ClassicMac/tree/v1.2.1>. The repository's
+The exact corresponding source is reproducible from the ClassicMac 1.3.0
+source at <https://github.com/amcchord/ClassicMac/tree/v1.3.0>. The repository's
 `scripts/build-qemu.sh` retrieves the pinned upstream QEMU 11.0.2 source and
 applies every ClassicMac modification stored in the repository.
 

--- a/cocoaui/window-presentation.patch
+++ b/cocoaui/window-presentation.patch
@@ -1,0 +1,167 @@
+diff --git a/ui/cocoa.m b/ui/cocoa.m
+index 00e07d700f3..74f021cd2ac 100644
+--- a/ui/cocoa.m
++++ b/ui/cocoa.m
+@@ -108,6 +108,10 @@ static void cocoa_switch(DisplayChangeListener *dcl,
+  */
+ static NSMenuItem *fullscreen_menu_item;
+ 
++/* ClassicMac: borderless-window state and its dynamically retitled menu item. */
++static NSMenuItem *titlebar_menu_item;
++static bool titlebar_hidden;
++
+ /* ClassicMac Tools CD: the drive id the host app always attaches for it and
+  * the environment variable through which the app publishes the image path. */
+ #define CLASSICMAC_TOOLS_DRIVE  "tools0"
+@@ -364,6 +368,8 @@ @interface QemuCocoaView : NSView
+     bool mouseOn;
+ }
+ - (void) switchSurface:(pixman_image_t *)image;
++- (void) applyTitleBarAppearance;
++- (void) toggleTitleBar;
+ - (void) grabMouse;
+ - (void) ungrabMouse;
+ - (void) setFullGrab:(id)sender;
+@@ -813,6 +819,54 @@ - (void) resendUIInfo
+     });
+ }
+ 
++/*
++ * Visually hide the titlebar without making the NSWindow truly borderless.
++ * Keeping NSWindowStyleMaskTitled preserves key-window behavior, native
++ * fullscreen, and edge resizing; FullSizeContentView plus transparent hidden
++ * chrome lets the guest view fill the complete window instead.
++ */
++- (void) applyTitleBarAppearance
++{
++    NSWindow *window = [self window];
++    NSWindowStyleMask styleMask;
++
++    /* AppKit owns the temporary fullscreen style mask. Apply the saved choice
++     * after windowDidExitFullScreen instead of mutating it mid-transition. */
++    if (!window || ([window styleMask] & NSWindowStyleMaskFullScreen)) {
++        return;
++    }
++
++    styleMask = [window styleMask];
++    if (titlebar_hidden) {
++        styleMask |= NSWindowStyleMaskFullSizeContentView;
++    } else {
++        styleMask &= ~NSWindowStyleMaskFullSizeContentView;
++    }
++    [window setStyleMask:styleMask];
++    [window setTitleVisibility:(titlebar_hidden ?
++                                NSWindowTitleHidden : NSWindowTitleVisible)];
++    [window setTitlebarAppearsTransparent:titlebar_hidden];
++    [window setTitlebarSeparatorStyle:(titlebar_hidden ?
++                                       NSTitlebarSeparatorStyleNone :
++                                       NSTitlebarSeparatorStyleAutomatic)];
++    [[window standardWindowButton:NSWindowCloseButton] setHidden:titlebar_hidden];
++    [[window standardWindowButton:NSWindowMiniaturizeButton] setHidden:titlebar_hidden];
++    [[window standardWindowButton:NSWindowZoomButton] setHidden:titlebar_hidden];
++
++    [self updateBounds];
++    [self updateUIInfo];
++}
++
++- (void) toggleTitleBar
++{
++    titlebar_hidden = !titlebar_hidden;
++    if (titlebar_menu_item) {
++        [titlebar_menu_item setTitle:(titlebar_hidden ?
++                                      @"Show Title Bar" : @"Hide Title Bar")];
++    }
++    [self applyTitleBarAppearance];
++}
++
+ - (void) switchSurface:(pixman_image_t *)image
+ {
+     COCOA_DEBUG("QemuCocoaView: switchSurface\n");
+@@ -1134,6 +1188,11 @@ - (bool) handleEventLocked:(NSEvent *)event
+                             [[self window] toggleFullScreen:nil];
+                             return true;
+ 
++                        /* ClassicMac: toggle the borderless-window look. */
++                        case 't':
++                            [self toggleTitleBar];
++                            return true;
++
+                         /* ClassicMac: re-push the current window size to
+                          * the guest in case it missed the last resolution
+                          * request. */
+@@ -1478,6 +1537,7 @@ @interface QemuCocoaAppController : NSObject
+ {
+ }
+ - (void)doToggleFullScreen:(id)sender;
++- (void)toggleTitleBar:(id)sender;
+ - (void)resendDisplayResolution:(id)sender;
+ - (void)showQEMUDoc:(id)sender;
+ - (void)zoomToFit:(id) sender;
+@@ -1611,6 +1671,10 @@ - (void)windowDidEnterFullScreen:(NSNotification *)notification
+     if (fullscreen_menu_item) {
+         [fullscreen_menu_item setTitle:@"Exit Fullscreen"];
+     }
++    /* Publish the final post-animation content frame. Intermediate resize
++     * notifications can still reflect the former titlebar-sized window. */
++    [cocoaView updateBounds];
++    [cocoaView updateUIInfo];
+     [cocoaView grabMouse];
+ }
+ 
+@@ -1620,6 +1684,6 @@ - (void)windowDidExitFullScreen:(NSNotification *)notification
+         [fullscreen_menu_item setTitle:@"Enter Fullscreen"];
+     }
+-    [cocoaView resizeWindow];
++    [cocoaView applyTitleBarAppearance];
+     [cocoaView ungrabMouse];
+ }
+ 
+@@ -1690,6 +1755,11 @@ - (void) doToggleFullScreen:(id)sender
+     [[cocoaView window] toggleFullScreen:sender];
+ }
+ 
++- (void) toggleTitleBar:(id)sender
++{
++    [cocoaView toggleTitleBar];
++}
++
+ /*
+  * ClassicMac: menu/dock action to push the current window size to the guest
+  * again, for when it missed the previous resolution-change request.
+@@ -1722,6 +1792,14 @@ - (NSMenu *) applicationDockMenu:(NSApplication *)sender
+     [item setTarget:self];
+     [dockMenu addItem:item];
+ 
++    item = [[[NSMenuItem alloc] initWithTitle:(titlebar_hidden ?
++                                               @"Show Title Bar" :
++                                               @"Hide Title Bar")
++                                       action:@selector(toggleTitleBar:)
++                                keyEquivalent:@""] autorelease];
++    [item setTarget:self];
++    [dockMenu addItem:item];
++
+     item = [[[NSMenuItem alloc] initWithTitle:@"Resend Screen Resolution"
+                                        action:@selector(resendDisplayResolution:)
+                                 keyEquivalent:@""] autorelease];
+@@ -2112,7 +2190,7 @@ static void create_initial_menus(void)
+     menu = [[NSMenu alloc] initWithTitle:@"View"];
+     /*
+      * ClassicMac: Control-Option key equivalents, matching the combos
+-     * handleEventLocked intercepts, so both commands keep working while the
++     * handleEventLocked intercepts, so the commands keep working while the
+      * emulator has grabbed the keyboard (fullscreen grabs it on entry -
+      * a Command shortcut would be swallowed by the guest there, which made
+      * fullscreen hard to leave).
+@@ -2121,6 +2199,12 @@ static void create_initial_menus(void)
+     [menuItem setKeyEquivalentModifierMask:(NSEventModifierFlagControl|NSEventModifierFlagOption)];
+     fullscreen_menu_item = menuItem;
+     [menu addItem: menuItem];
++    /* ClassicMac: visually remove/restore the titlebar while preserving a
++     * normal key-capable, resizable NSWindow underneath. */
++    menuItem = [[[NSMenuItem alloc] initWithTitle:@"Hide Title Bar" action:@selector(toggleTitleBar:) keyEquivalent:@"t"] autorelease];
++    [menuItem setKeyEquivalentModifierMask:(NSEventModifierFlagControl|NSEventModifierFlagOption)];
++    titlebar_menu_item = menuItem;
++    [menu addItem: menuItem];
+     /* ClassicMac: ask the guest to switch to the window's resolution again,
+      * for when it missed the request that accompanied the last resize. */
+     menuItem = [[[NSMenuItem alloc] initWithTitle:@"Resend Screen Resolution" action:@selector(resendDisplayResolution:) keyEquivalent:@"r"] autorelease];

--- a/qfb/cocoa-resize.patch
+++ b/qfb/cocoa-resize.patch
@@ -27,10 +27,10 @@ diff --git a/ui/cocoa.m b/ui/cocoa.m
 +     * produces an oversized window. We deliberately do NOT lock the window's
 +     * aspect ratio, so the user can freely drag it toward any resolution.
 +     */
-+    if ([[self window] styleMask] & NSWindowStyleMaskFullScreen) {
-+        [[self window] setContentSize:[self fixAspectRatio:[self screenSafeAreaSize]]];
-+        [[self window] center];
-+    } else {
++    if (!([[self window] styleMask] & NSWindowStyleMaskFullScreen)) {
++        /* Native fullscreen windows are sized by AppKit. Only resize windowed
++         * content here; the guest follows the actual fullscreen view instead. */
++
          CGFloat width = screen.width;
          CGFloat height = screen.height;
          NSSize maxSize = [self screenSafeAreaSize];
@@ -46,7 +46,19 @@ diff --git a/ui/cocoa.m b/ui/cocoa.m
      }
  }
  
-@@ -706,8 +705,15 @@
+@@ -663,10 +662,9 @@
+         CGDirectDisplayID display = [[description objectForKey:@"NSScreenNumber"] unsignedIntValue];
+         NSSize screenSize = [[[self window] screen] frame].size;
+         CGSize screenPhysicalSize = CGDisplayScreenSize(display);
+-        bool isFullscreen = ([[self window] styleMask] & NSWindowStyleMaskFullScreen) != 0;
+         CVDisplayLinkRef displayLink;
+ 
+-        frameSize = isFullscreen ? [self screenSafeAreaSize] : [self frame].size;
++        frameSize = [self frame].size;
+ 
+         if (!CVDisplayLinkCreateWithCGDisplay(display, &displayLink)) {
+             CVTime period = CVDisplayLinkGetNominalOutputVideoRefreshPeriod(displayLink);
+@@ -706,8 +704,15 @@
  
      info.xoff = 0;
      info.yoff = 0;
@@ -64,7 +76,7 @@ diff --git a/ui/cocoa.m b/ui/cocoa.m
  
      dpy_set_ui_info(dcl.con, &info, TRUE);
  }
-@@ -1317,12 +1323,20 @@
+@@ -1317,12 +1322,20 @@
  
          // create a window
          window = [[NSWindow alloc] initWithContentRect:[cocoaView frame]
@@ -86,7 +98,7 @@ diff --git a/ui/cocoa.m b/ui/cocoa.m
          [window setAcceptsMouseMovedEvents:YES];
          [window setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
          [window setTitle:qemu_name ? [NSString stringWithFormat:@"QEMU %s", qemu_name] : @"QEMU"];
-@@ -1411,6 +1425,24 @@
+@@ -1411,6 +1424,24 @@
  - (void)windowDidResize:(NSNotification *)notification
  {
      [cocoaView updateBounds];

--- a/scripts/build-qemu.sh
+++ b/scripts/build-qemu.sh
@@ -167,9 +167,12 @@ git -C "$QEMU_DIR" apply "$ROOT_DIR/cocoaui/removable-media-names.patch" || die 
 # Control+click, scroll wheel as arrow keys) while the machine runs.
 git -C "$QEMU_DIR" apply "$ROOT_DIR/cocoaui/input-helpers-menu.patch" || die "Failed to apply ClassicMac input helpers menu patch"
 # Control-Option-F fullscreen toggle (works even while input is grabbed, so
-# fullscreen is easy to leave), Control-Option-R to re-push the window's
-# resolution to the guest, both in the View menu and the Dock icon menu.
+# fullscreen is easy to leave) and Control-Option-R to re-push the window's
+# resolution to the guest, with View menu and Dock icon entries.
 git -C "$QEMU_DIR" apply "$ROOT_DIR/cocoaui/fullscreen-resolution-menu.patch" || die "Failed to apply ClassicMac fullscreen/resolution menu patch"
+# Control-Option-T borderless-window toggle plus final-frame reporting after
+# native fullscreen transitions, so the guest uses the complete drawable area.
+git -C "$QEMU_DIR" apply "$ROOT_DIR/cocoaui/window-presentation.patch" || die "Failed to apply ClassicMac window presentation patch"
 # Apple Sound Chip: always feed the audio backend silence when idle so a live
 # backend (CoreAudio) never replays stale ring-buffer content as a hum/buzz.
 git -C "$QEMU_DIR" apply "$QFB_DIR/asc-silence.patch" || die "Failed to apply asc silence patch"

--- a/scripts/bundle-qemu.sh
+++ b/scripts/bundle-qemu.sh
@@ -38,7 +38,7 @@ HELPERS_DIR="$CONTENTS/Helpers"
 QUADRA_APP="$HELPERS_DIR/Quadra 800.app"
 PPC_APP="$HELPERS_DIR/Power Mac G4.app"
 
-APP_VERSION="${APP_VERSION:-1.2.1}"
+APP_VERSION="${APP_VERSION:-1.3.0}"
 BUNDLE_ID="com.classicmac.emulator"
 
 log() { printf '\n==> %s\n' "$*"; }
@@ -305,6 +305,8 @@ write_helper_plist() {
 	<string>15.0</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSPrefersDisplaySafeAreaCompatibilityMode</key>
+	<false/>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 </dict>


### PR DESCRIPTION
## What changed

- Add a borderless machine-window presentation with View and Dock commands plus the always-reachable Control-Option-T shortcut.
- Make fullscreen guest sizing follow the final Cocoa content frame instead of subtracting a titlebar or display safe-area inset.
- Preserve AppKit's restored window geometry when leaving fullscreen.
- Opt machine helpers out of camera-housing compatibility mode so fullscreen uses the complete logical display.
- Bump ClassicMac and its corresponding-source notices to 1.3.0.

## Why

The machine window could not hide its chrome, and native fullscreen requested a guest mode one safe-area/titlebar height shorter than the actual display. The old exit callback could also resize AppKit's restored window from the stale fullscreen guest surface.

## Validation

- Clean QEMU 11.0.2 patch-stack replay matches the generated Cocoa source byte-for-byte.
- Both `qemu-system-m68k` and `qemu-system-ppc` build successfully.
- All 8 Swift tests pass.
- The 1.3.0 app and DMG are Developer ID signed, Apple-notarized, stapled, and accepted by Gatekeeper.
- Release DMG SHA-256: `be30f151dd12c1f67d76c4f5ec76d49fba8b00eaec01890c343d7e139a86f30e`.