### PR TITLE
Release 1.4.0 with Mac-native menus and reliable disc controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 1.4.0 — 2026-07-11
+
+### Added
+
+- **Mac-native menus for running machines.** The Mac menu now provides Pause,
+  Resume, Restart, Shut Down, a state-aware ClassicMac Tools command, a Disc
+  submenu, and Secondary Click and Scrolling. The View menu focuses on Full
+  Screen, title-bar presentation, matching the Mac screen to the window, and
+  smooth scaling. Raw QEMU consoles, backend identifiers, developer speed
+  controls, and QEMU documentation are no longer exposed.
+- **A permanent user-facing disc tray.** Both machine families keep a Disc
+  drive available even when it starts empty, so a disc image can be inserted
+  or ejected from the Mac menu without restarting the machine.
+
+### Fixed
+
+- **ClassicMac Tools now inserts and ejects reliably while a Mac is running.**
+  The Power Mac's Tools drive previously landed beside the hard disk instead
+  of on its optical IDE channel, so QEMU accepted a media change but Mac OS 9
+  never saw the disc. Power Macs now use dedicated optical positions, while
+  Quadras keep separate fixed SCSI positions for the Disc and Tools trays.
+- **Power Macs still start correctly from a selected installation disc.**
+  OpenBIOS probes only the primary optical position for CD startup. During a
+  disc startup, ClassicMac temporarily gives that position to the selected
+  disc and leaves Tools empty in the secondary position; normal hard-disk
+  startups continue to put Tools first.
+- **Disc errors are clearer and safer.** Menu actions target the exact Disc
+  tray, keep implementation details in the log, and distinguish a busy drive
+  from an image that cannot be opened or read.
+
 ## 1.3.0 — 2026-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ ClassicMac exists because of years of brilliant work by other engineers. The pat
 - **Host folder sharing on both machines.** Pick a folder and it mounts on the emulated desktop as a read/write disk (classicvirtio + virtio-9p). Resource forks and type/creator codes round-trip via `.rdump`/`.idump` sidecars.
 - **Clean, working sound.** The Quadra's Apple Sound Chip is patched to feed silence when idle (no more idle buzz), and the Power Mac gets the screamer (AWACS) device with a screamer-aware OpenBIOS.
 - **Self-contained `.classic` machine documents.** Each VM is a single Finder package holding its config, disk, and PRAM. Keep it anywhere, double-click to boot, move it between Macs.
-- **Classic input helpers.** Right-click opens contextual menus as Control+click, and the scroll wheel becomes arrow-key taps — both per-VM toggles for guests with real drivers (e.g. USB Overdrive).
-- **A guest-additions Tools CD** (StuffIt Expander, Disk Copy, USB Overdrive, Transmit, Lido, patched HD SC Setup...) built from `guestcd/manifest.tsv`, insertable at runtime from the machine window's menu — everything pre-expanded and ready to run.
-- **Native machine control.** Pause / Resume, Restart, and Power Off from the app via QEMU's monitor socket, live screen previews in the library, and a "Match Display" button that sizes the Mac to your screen.
-- **Machine window shortcuts that always work.** Control-Option-T hides or restores the title bar for a clean borderless look, Control-Option-F toggles fullscreen, and Control-Option-R re-pushes the window's resolution to the guest. All three keep working even while the emulator has grabbed the keyboard, and they also live in the View menu and the machine's Dock icon menu.
+- **Classic input helpers.** Secondary click opens contextual menus as Control+click, and the scroll wheel becomes arrow-key taps. Toggle both together while the Mac is running with **Mac → Secondary Click and Scrolling**, or turn them off for guests with real drivers (e.g. USB Overdrive).
+- **A guest-additions Tools CD** (StuffIt Expander, Disk Copy, USB Overdrive, Transmit, Lido, patched HD SC Setup...) built from `guestcd/manifest.tsv`, insertable at runtime from the **Mac** menu. The action changes between **Insert “ClassicMac Tools”** and **Eject “ClassicMac Tools”** to match the current state; **Mac → Disc** handles other disc images — everything on the Tools CD is pre-expanded and ready to run.
+- **Native machine control.** Pause / Resume, Restart, and Shut Down from the app, live screen previews in the library, and a "Match Display" button that sizes the Mac to your screen.
+- **Machine window shortcuts that always work.** Control-Option-T hides or restores the title bar for a clean borderless look, Control-Option-F toggles Full Screen, and Control-Option-R matches the Mac screen to the window again. All three keep working even while the emulator has grabbed the keyboard, and they also live in the **View** menu and the machine's Dock icon menu.
 - **Signed, notarized, stapled DMG** for distribution — recipients get a clean Gatekeeper experience even offline.
 
 ## Getting started
@@ -80,10 +80,10 @@ ClassicMac exists because of years of brilliant work by other engineers. The pat
 > regular installation. ClassicMac's QEMU build fixes the MacIO IDE/DBDMA
 > completion race that made some 9.2.1 and 9.2.2 installers freeze around
 > "About 4 minutes remaining," so a frozen partial System Folder is no longer
-> expected or considered a successful install. During a Power Mac CD boot, the
-> Tools CD starts with an empty tray when networking is enabled to avoid a Mac
-> OS 9.2.1 startup crash; after Finder appears, insert it from the QEMU
-> **Machine** menu if needed.
+> expected or considered a successful install. During a Power Mac CD boot,
+> ClassicMac leaves the Tools tray empty so the selected startup disc boots
+> cleanly; after Finder appears, choose **Mac → Insert “ClassicMac Tools”** if
+> needed.
 
 New machines are created as `.classic` documents (default `~/Documents/ClassicMac/`). Double-click one in Finder to boot it.
 
@@ -93,9 +93,9 @@ Requirements: an Apple Silicon Mac (M1 or later) running a recent macOS.
 
 - The resolution you pick is the *boot* resolution and the depth is the *deepest available* mode; classic Mac OS chooses the active depth at startup (a fresh system comes up in B&W until you pick Thousands/Millions once in Monitors — it's remembered per machine).
 - Live resolution switching relies on the Display Manager, so it needs Mac OS ~7.6+ on the Quadra; on the Power Mac it works throughout Mac OS 9. Older systems still boot fine at the configured resolution and scale to the window. Power Mac widths snap down to a multiple of 8 (a VGA hardware constraint).
-- If the guest ever misses a resolution change (the window resized but the Mac stayed at the old size), pick **View → Resend Screen Resolution** (Control-Option-R) — also available from the machine's Dock icon menu — to ask it again.
+- If the guest ever misses a resolution change (the window resized but the Mac stayed at the old size), pick **View → Match Mac Screen to Window** (Control-Option-R) — also available from the machine's Dock icon menu — to ask it again.
 - For a borderless machine window, choose **View → Hide Title Bar** or press **Control-Option-T**. Use the same shortcut (or **Show Title Bar**) to restore the normal window controls.
-- To leave fullscreen press **Control-Option-F** (it also enters it). The combo works even while the emulator has grabbed the keyboard; it's listed in the View menu and the Dock icon menu.
+- To leave Full Screen, press **Control-Option-F** (it also enters it). The combo works even while the emulator has grabbed the keyboard; the **View** menu and Dock icon menu show **Enter Full Screen** or **Exit Full Screen** to match the current state.
 - The Power Mac's packed low-bpp patch adds Black & White, 4 and 16 colors to the Monitors panel alongside 256/thousands/millions.
 - Mac OS 9 wants **less than 1 GB of RAM** for stable sound, so the app's presets stop at 896 MB.
 - On the Quadra, folder sharing arrives through the classicvirtio NuBus card firmware (new machines start from a pre-seeded PRAM so it boots reliably). On the Power Mac it arrives through `virtio-9p-pci` and the classicvirtio ndrvloader placed in guest RAM at boot; while booting from CD (e.g. an OS install) sharing is temporarily inactive.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -11,8 +11,8 @@ QEMU emulator as a whole is licensed under the GNU General Public License,
 version 2. Individual source and firmware files may carry compatible licenses,
 as described by QEMU's `LICENSE` file and their source headers.
 
-The exact corresponding source is reproducible from the ClassicMac 1.3.0
-source at <https://github.com/amcchord/ClassicMac/tree/v1.3.0>. The repository's
+The exact corresponding source is reproducible from the ClassicMac 1.4.0
+source at <https://github.com/amcchord/ClassicMac/tree/v1.4.0>. The repository's
 `scripts/build-qemu.sh` retrieves the pinned upstream QEMU 11.0.2 source and
 applies every ClassicMac modification stored in the repository.
 

--- a/app/Sources/ClassicMac/NewVMSheet.swift
+++ b/app/Sources/ClassicMac/NewVMSheet.swift
@@ -293,7 +293,7 @@ struct NewVMSheet: View {
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.canCreateDirectories = true
-        panel.message = "Choose a folder on your Mac to share with the emulated Mac"
+        panel.message = "Choose a folder on this Mac to share with your classic Mac"
         if panel.runModal() == .OK {
             sharedFolderURL = panel.url
         }

--- a/app/Sources/ClassicMac/QEMURunner.swift
+++ b/app/Sources/ClassicMac/QEMURunner.swift
@@ -96,8 +96,8 @@ final class QEMUManager: ObservableObject {
         process.arguments = QEMUManager.buildArguments(for: config)
         process.currentDirectoryURL = config.folder
 
-        // Tell the QEMU window where the bundled Tools CD lives so its
-        // Machine menu can offer "Insert Tools CD" while the Mac runs.
+        // Tell the running Mac window where the bundled tools disc lives so
+        // its Mac menu can insert or eject it while the Mac runs.
         var environment = ProcessInfo.processInfo.environment
         if let toolsCD = AppPaths.toolsCD {
             environment["CLASSICMAC_TOOLS_CD"] = toolsCD.path
@@ -129,7 +129,7 @@ final class QEMUManager: ObservableObject {
                     monitor?.cancel()
                     self.lastError = AppError(
                         "\u{201C}\(config.name)\u{201D} Shut Down Unexpectedly",
-                        "The emulated Mac stopped on its own. Try starting it again.",
+                        "The Mac stopped on its own. Try starting it again.",
                         logURL: AppLog.write(message, machineName: config.name)
                     )
                     return
@@ -151,7 +151,7 @@ final class QEMUManager: ObservableObject {
         } catch {
             lastError = AppError(
                 "Couldn't Start \u{201C}\(config.name)\u{201D}",
-                "The emulator could not be launched. \(error.localizedDescription)"
+                "The Mac could not be started. \(error.localizedDescription)"
             )
             return
         }
@@ -364,19 +364,25 @@ final class QEMUManager: ObservableObject {
         return ""
     }
 
-    // The dedicated Tools CD drive (id=tools0). Starts loaded with the
-    // bundled ClassicMac Tools image when the VM's settings ask for it,
-    // otherwise as an empty tray the Machine menu can fill at runtime.
+    // The dedicated Tools CD drive (id=tools0). It starts loaded when the
+    // machine's settings ask for it; otherwise the Mac menu can fill its
+    // empty tray while the machine is running.
     private static func toolsDriveSpec(
         for config: VMConfig,
         iface: String,
+        index: Int? = nil,
         loadMedia: Bool = true
     ) -> String {
-        var spec = "if=\(iface),media=cdrom,id=tools0"
-        if loadMedia, config.toolsCDInserted, let toolsCD = AppPaths.toolsCD {
-            spec += ",file=\(toolsCD.path),format=raw"
+        var options = ["if=\(iface)"]
+        if let index {
+            options.append("index=\(index)")
         }
-        return spec
+        options += ["media=cdrom", "id=tools0"]
+        if loadMedia, config.toolsCDInserted, let toolsCD = AppPaths.toolsCD {
+            options += ["file=\(toolsCD.path)", "format=raw"]
+        }
+        options.append("readonly=on")
+        return options.joined(separator: ",")
     }
 
     // qemu-system-ppc -M mac99: a New World Power Mac that boots Mac OS 8.5
@@ -395,7 +401,7 @@ final class QEMUManager: ObservableObject {
         // loader, but remains enabled: after injecting its NDRV the loader runs
         // Open Firmware's normal `boot` command, which still honors `-boot d`.
         let bootingFromUserCD = config.bootFromCD && config.cdImagePath?.isEmpty == false
-        let deferToolsMedia = bootingFromUserCD && config.networking
+        let deferToolsMedia = bootingFromUserCD
         let sharing = config.hasSharedFolder && !bootingFromUserCD
         let tablet = config.tabletInput
         let needsNdrvLoader = sharing || tablet
@@ -483,27 +489,38 @@ final class QEMUManager: ObservableObject {
         // Main IDE hard disk.
         args += ["-drive", "file=\(config.diskImageURL.path),format=raw,media=disk"]
 
-        // Optional IDE CD-ROM.
+        // Keep a user-facing disc tray present on the optical IDE channel,
+        // even when it starts empty, so the running window's Disc menu can
+        // insert an image later. OpenBIOS only tries the primary optical unit
+        // for `-boot d`, so temporarily give that position to the selected
+        // startup disc. Normal hard-disk starts reserve it for Tools.
+        let userDiscIndex = bootingFromUserCD ? 2 : 3
+        var userDisc = "if=ide,index=\(userDiscIndex),media=cdrom,id=cd0,readonly=on"
         if let cdPath = config.cdImagePath, !cdPath.isEmpty {
-            args += ["-drive", "file=\(cdPath),format=raw,media=cdrom"]
-            if config.bootFromCD {
-                args += ["-boot", "d"]
-            }
+            userDisc += ",file=\(cdPath),format=raw"
+        }
+        args += ["-drive", userDisc]
+        if bootingFromUserCD {
+            args += ["-boot", "d"]
         }
 
-        // Dedicated second CD drive for the ClassicMac Tools CD. Always
-        // present so the QEMU window's Machine menu can insert/eject the
-        // Tools CD while the Mac is running; loaded at boot when the VM's
-        // settings say so. Keep its tray empty while starting a networked
-        // Power Mac from another CD: Mac OS 9.2.1's startup is unstable when
-        // it mounts a second CD alongside the installer and initializes
-        // Sungem. The empty drive remains available, so the Machine menu can
-        // insert the Tools image after Finder appears. With networking off,
-        // the requested Tools media is safe to load normally.
-        args += [
-            "-drive",
-            toolsDriveSpec(for: config, iface: "ide", loadMedia: !deferToolsMedia)
-        ]
+        // Put ClassicMac Tools on the Power Mac's optical IDE channel. The
+        // former automatic placement made it the hard disk's IDE slave, which
+        // Mac OS 9 did not treat as its removable CD tray; QEMU accepted menu
+        // media changes, but Finder never saw them. Normally Tools occupies
+        // the primary optical position. When starting from a selected CD, it
+        // moves to the secondary position and stays empty so OpenBIOS boots
+        // that selected disc and the installer starts with only one mounted
+        // CD. Tools can be inserted from the Mac menu afterward.
+        let loadToolsMedia = !deferToolsMedia && config.toolsCDInserted &&
+            AppPaths.toolsCD != nil
+        let toolsDiscIndex = bootingFromUserCD ? 3 : 2
+        args += ["-drive", toolsDriveSpec(
+            for: config,
+            iface: "ide",
+            index: toolsDiscIndex,
+            loadMedia: loadToolsMedia
+        )]
 
         // User-mode networking through the mac99 onboard sungem ethernet.
         if config.networking {
@@ -600,14 +617,17 @@ final class QEMUManager: ObservableObject {
         args += ["-device", "scsi-hd,scsi-id=0,drive=hd0"]
         args += ["-drive", "file=\(config.diskImageURL.path),media=disk,format=raw,if=none,id=hd0"]
 
-        // Optional CD-ROM at SCSI ID 3.
+        // User-facing CD-ROM at SCSI ID 3. Keep its tray available even when
+        // empty so the running window's Disc menu can insert an image.
+        args += ["-device", "scsi-cd,scsi-id=3,drive=cd0"]
+        var userDisc = "media=cdrom,if=none,id=cd0,readonly=on"
         if let cdPath = config.cdImagePath, !cdPath.isEmpty {
-            args += ["-device", "scsi-cd,scsi-id=3,drive=cd0"]
-            args += ["-drive", "file=\(cdPath),media=cdrom,if=none,id=cd0"]
+            userDisc += ",file=\(cdPath),format=raw"
             if config.bootFromCD {
                 args += ["-boot", "d"]
             }
         }
+        args += ["-drive", userDisc]
 
         // Dedicated second CD drive (SCSI ID 4) for the ClassicMac Tools CD;
         // see the Power Mac builder for the rationale.

--- a/app/Sources/ClassicMac/VMDetailView.swift
+++ b/app/Sources/ClassicMac/VMDetailView.swift
@@ -346,8 +346,8 @@ struct VMDetailView: View {
 
             Toggle(isOn: vm.classicInputHelpers) {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Right-click & scroll wheel helpers")
-                    Text("Right-click opens contextual menus (Control+click) and the scroll wheel scrolls via arrow keys. Turn off if USB Overdrive is installed in this Mac.")
+                    Text("Secondary click & scrolling")
+                    Text("Right-click opens contextual menus, and the scroll wheel scrolls in classic Mac apps. Turn this off if USB Overdrive is installed.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -356,8 +356,8 @@ struct VMDetailView: View {
 
             Toggle(isOn: vm.tabletInput) {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Tablet input (seamless mouse)")
-                    Text("The mouse moves freely in and out of the Mac window without capturing. Uses the classicvirtio tablet driver.")
+                    Text("Seamless mouse")
+                    Text("Move the pointer freely in and out of the Mac window without releasing it first.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -412,16 +412,16 @@ struct VMDetailView: View {
             if AppPaths.toolsCD != nil {
                 Toggle(isOn: vm.toolsCDInserted) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Tools CD")
-                        if vm.wrappedValue.machineFamily == .powerMacG4 &&
+                        Text("ClassicMac Tools")
+                        if vm.wrappedValue.toolsCDInserted &&
+                            vm.wrappedValue.machineFamily == .powerMacG4 &&
                             vm.wrappedValue.bootFromCD &&
-                            vm.wrappedValue.cdImagePath?.isEmpty == false &&
-                            vm.wrappedValue.networking {
-                            Text("With networking enabled, the Tools tray starts empty during a Power Mac CD boot for Mac OS 9 compatibility. After the desktop appears, insert it from the Machine menu.")
+                            vm.wrappedValue.cdImagePath?.isEmpty == false {
+                            Text("During this Power Mac disc startup, ClassicMac Tools waits until the desktop appears. Then choose Insert “ClassicMac Tools” from the Mac menu.")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         } else {
-                            Text("Guest essentials in a second CD drive: StuffIt Expander, Disk Copy, a CD image mounter, and (Power Mac) the USB Overdrive scroll wheel driver. Can also be inserted from the Machine menu while the Mac is running.")
+                            Text("Useful classic Mac apps, including StuffIt Expander, Disk Copy, a disc image mounter, and USB Overdrive for Power Macs. You can insert or eject it from the Mac menu while the Mac is running.")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -430,7 +430,9 @@ struct VMDetailView: View {
                 .disabled(running)
             }
         } header: {
-            Label("CD-ROM", systemImage: "opticaldiscdrive")
+            Label("Discs", systemImage: "opticaldiscdrive")
+        } footer: {
+            Text("While the Mac is running, use Mac → Disc to insert or eject a disc image.")
         }
     }
 
@@ -481,7 +483,7 @@ struct VMDetailView: View {
                 Text("Appears on the Mac desktop as the disk \u{201C}\(vm.sharedVolumeName)\u{201D}.")
             }
         } else {
-            Text("Share a folder from this Mac so its files appear on the emulated Mac's desktop.")
+            Text("Share a folder from this Mac so its files appear on your classic Mac's desktop.")
         }
     }
 
@@ -491,7 +493,7 @@ struct VMDetailView: View {
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.canCreateDirectories = true
-        panel.message = "Choose a folder on your Mac to share with the emulated Mac"
+        panel.message = "Choose a folder on this Mac to share with your classic Mac"
         if panel.runModal() == .OK, let url = panel.url {
             vm.wrappedValue.sharedFolderPath = url.path
         }

--- a/app/Tests/ClassicMacTests/QEMURunnerArgumentTests.swift
+++ b/app/Tests/ClassicMacTests/QEMURunnerArgumentTests.swift
@@ -6,6 +6,7 @@ import Darwin
 final class QEMURunnerArgumentTests: XCTestCase {
     private func config(
         family: MachineFamily = .powerMacG4,
+        cdImagePath: String? = "/tmp/install.iso",
         bootFromCD: Bool = true,
         toolsCDInserted: Bool = true,
         networking: Bool = true,
@@ -16,7 +17,7 @@ final class QEMURunnerArgumentTests: XCTestCase {
             name: "Argument Test",
             machineFamily: family,
             ramMB: family.defaultRAMMB,
-            cdImagePath: "/tmp/install.iso",
+            cdImagePath: cdImagePath,
             bootFromCD: bootFromCD,
             toolsCDInserted: toolsCDInserted,
             networking: networking,
@@ -68,7 +69,18 @@ final class QEMURunnerArgumentTests: XCTestCase {
             let toolsDrive = optionValues("-drive", in: arguments)
                 .first { $0.contains("id=tools0") }
 
-            XCTAssertEqual(toolsDrive, "if=ide,media=cdrom,id=tools0")
+            XCTAssertEqual(
+                toolsDrive,
+                "if=ide,index=3,media=cdrom,id=tools0,readonly=on"
+            )
+            let userDisc = optionValues("-drive", in: arguments)
+                .first { $0.contains("id=cd0") }
+            XCTAssertEqual(
+                userDisc,
+                "if=ide,index=2,media=cdrom,id=cd0,readonly=on,file=/tmp/install.iso,format=raw"
+            )
+            let devices = optionValues("-device", in: arguments)
+            XCTAssertFalse(devices.contains { $0.contains("classicmac-tools") })
             XCTAssertTrue(optionValues("-nic", in: arguments).contains("user,model=sungem"))
         }
     }
@@ -80,12 +92,20 @@ final class QEMURunnerArgumentTests: XCTestCase {
                 optionValues("-drive", in: arguments).first { $0.contains("id=tools0") }
             )
 
-            XCTAssertTrue(toolsDrive.contains("file="))
-            XCTAssertTrue(toolsDrive.hasSuffix(",format=raw"))
+            XCTAssertTrue(
+                toolsDrive.hasPrefix(
+                    "if=ide,index=2,media=cdrom,id=tools0,file="
+                )
+            )
+            XCTAssertTrue(toolsDrive.hasSuffix(",format=raw,readonly=on"))
+            XCTAssertFalse(
+                optionValues("-device", in: arguments)
+                    .contains { $0.contains("classicmac-tools") }
+            )
         }
     }
 
-    func testPowerMacCDStartupCanLoadToolsWhenNetworkingIsOff() throws {
+    func testPowerMacCDStartupKeepsToolsTrayEmptyWhenNetworkingIsOff() throws {
         try withTemporaryToolsCD {
             let arguments = QEMUManager.buildArguments(
                 for: config(networking: false)
@@ -94,9 +114,124 @@ final class QEMURunnerArgumentTests: XCTestCase {
                 optionValues("-drive", in: arguments).first { $0.contains("id=tools0") }
             )
 
-            XCTAssertTrue(toolsDrive.contains("file="))
+            XCTAssertEqual(
+                toolsDrive,
+                "if=ide,index=3,media=cdrom,id=tools0,readonly=on"
+            )
+            XCTAssertEqual(
+                optionValues("-drive", in: arguments)
+                    .first { $0.contains("id=cd0") },
+                "if=ide,index=2,media=cdrom,id=cd0,readonly=on,file=/tmp/install.iso,format=raw"
+            )
             XCTAssertEqual(optionValues("-nic", in: arguments), ["none"])
         }
+    }
+
+    func testPowerMacToolsPreferenceOffKeepsRemovableDriveEmpty() throws {
+        try withTemporaryToolsCD {
+            let arguments = QEMUManager.buildArguments(
+                for: config(
+                    bootFromCD: false,
+                    toolsCDInserted: false,
+                    networking: false
+                )
+            )
+            let toolsDrive = try XCTUnwrap(
+                optionValues("-drive", in: arguments).first { $0.contains("id=tools0") }
+            )
+
+            XCTAssertEqual(
+                toolsDrive,
+                "if=ide,index=2,media=cdrom,id=tools0,readonly=on"
+            )
+        }
+    }
+
+    func testPowerMacKeepsAnEmptyUserDiscTrayAvailable() {
+        let arguments = QEMUManager.buildArguments(
+            for: config(
+                cdImagePath: nil,
+                bootFromCD: false,
+                toolsCDInserted: false
+            )
+        )
+
+        XCTAssertTrue(optionValues("-boot", in: arguments).isEmpty)
+        XCTAssertEqual(
+            optionValues("-drive", in: arguments)
+                .first { $0.contains("id=cd0") },
+            "if=ide,index=3,media=cdrom,id=cd0,readonly=on"
+        )
+    }
+
+    func testQuadraToolsDriveRemainsOnDedicatedSCSIPosition() throws {
+        try withTemporaryToolsCD {
+            let arguments = QEMUManager.buildArguments(
+                for: config(family: .quadra800, bootFromCD: false)
+            )
+            let toolsDrive = try XCTUnwrap(
+                optionValues("-drive", in: arguments).first { $0.contains("id=tools0") }
+            )
+
+            XCTAssertTrue(
+                toolsDrive.hasPrefix("if=none,media=cdrom,id=tools0,file=")
+            )
+            XCTAssertFalse(toolsDrive.contains("bus="))
+            XCTAssertFalse(toolsDrive.contains("unit="))
+            XCTAssertTrue(
+                optionValues("-device", in: arguments)
+                    .contains(
+                        "scsi-cd,scsi-id=4,drive=tools0"
+                    )
+            )
+        }
+    }
+
+    func testQuadraToolsPreferenceOffKeepsSCSITrayEmpty() throws {
+        try withTemporaryToolsCD {
+            let arguments = QEMUManager.buildArguments(
+                for: config(
+                    family: .quadra800,
+                    bootFromCD: false,
+                    toolsCDInserted: false
+                )
+            )
+            let toolsDrive = try XCTUnwrap(
+                optionValues("-drive", in: arguments).first { $0.contains("id=tools0") }
+            )
+
+            XCTAssertEqual(
+                toolsDrive,
+                "if=none,media=cdrom,id=tools0,readonly=on"
+            )
+            XCTAssertTrue(
+                optionValues("-device", in: arguments)
+                    .contains(
+                        "scsi-cd,scsi-id=4,drive=tools0"
+                    )
+            )
+        }
+    }
+
+    func testQuadraKeepsAnEmptyUserDiscTrayAvailable() {
+        let arguments = QEMUManager.buildArguments(
+            for: config(
+                family: .quadra800,
+                cdImagePath: nil,
+                bootFromCD: false,
+                toolsCDInserted: false
+            )
+        )
+
+        XCTAssertTrue(
+            optionValues("-device", in: arguments)
+                .contains("scsi-cd,scsi-id=3,drive=cd0")
+        )
+        XCTAssertEqual(
+            optionValues("-drive", in: arguments)
+                .first { $0.contains("id=cd0") },
+            "media=cdrom,if=none,id=cd0,readonly=on"
+        )
     }
 
     func testNetworkingOffExplicitlyDisablesDefaultNICs() {

--- a/cocoaui/mac-native-menus.patch
+++ b/cocoaui/mac-native-menus.patch
@@ -1,0 +1,627 @@
+--- a/ui/cocoa.m
++++ b/ui/cocoa.m
+@@ -42,7 +42,6 @@
+ #include "qapi/qapi-commands-block.h"
+ #include "qapi/qapi-commands-machine.h"
+ #include "qapi/qapi-commands-misc.h"
+-#include "system/blockdev.h"
+ #include "qemu-version.h"
+ #include "qemu/cutils.h"
+ #include "qemu/main-loop.h"
+@@ -104,7 +103,7 @@
+ static bool scroll_keys;
+ /*
+  * ClassicMac: the View menu's fullscreen item, retitled between
+- * "Enter Fullscreen" and "Exit Fullscreen" as the window transitions.
++ * "Enter Full Screen" and "Exit Full Screen" as the window transitions.
+  */
+ static NSMenuItem *fullscreen_menu_item;
+ 
+@@ -117,6 +116,14 @@
+ #define CLASSICMAC_TOOLS_DRIVE  "tools0"
+ #define CLASSICMAC_TOOLS_CD_ENV "CLASSICMAC_TOOLS_CD"
+ 
++#define CLASSICMAC_DISC_DRIVE "cd0"
++
++/* Native, stateful media controls for the running Mac's menus. */
++static NSMenuItem *tools_cd_menu_item;
++static NSMenuItem *disc_eject_menu_item;
++static NSMenuItem *input_helpers_menu_item;
++static NSString *classicmac_disc_drive;
++
+ static CGInterpolationQuality zoom_interpolation = kCGInterpolationNone;
+ static NSTextField *pauseLabel;
+ 
+@@ -178,8 +183,44 @@
+         bql_unlock();
+     }
+     return val;
++}
++
++/* Must be called with the BQL held. */
++static bool classicmac_drive_matches_media(const char *drive,
++                                           const char *filename)
++{
++    BlockInfoList *devices = qmp_query_block(false, false, NULL);
++    BlockInfoList *current = devices;
++    bool inserted = false;
++
++    while (current) {
++        if (current->value->device &&
++            strcmp(current->value->device, drive) == 0) {
++            inserted = current->value->inserted != NULL &&
++                (!filename ||
++                 g_strcmp0(current->value->inserted->file, filename) == 0);
++            break;
++        }
++        current = current->next;
++    }
++
++    qapi_free_BlockInfoList(devices);
++    return inserted;
+ }
+ 
++static bool classicmac_drive_has_media(const char *drive)
++{
++    return classicmac_drive_matches_media(drive, NULL);
++}
++
++/* Must be called with the BQL held. */
++static bool classicmac_tools_are_inserted(void)
++{
++    const char *path = getenv(CLASSICMAC_TOOLS_CD_ENV);
++    return path && path[0] != '\0' &&
++        classicmac_drive_matches_media(CLASSICMAC_TOOLS_DRIVE, path);
++}
++
+ // Mac to QKeyCode conversion
+ static const int mac_to_qkeycode_map[] = {
+     [kVK_ANSI_A] = Q_KEY_CODE_A,
+@@ -323,14 +364,25 @@
+     [alert runModal];
+ }
+ 
+-/* Handles any errors that happen with a device transaction */
+-static void handleAnyDeviceErrors(Error * err)
++/* Keep implementation details in the log and give people an actionable,
++ * Mac-style explanation in the UI. Returns true when it handled an error. */
++static bool classicmac_handle_media_error(Error *err, NSString *message,
++                                          NSString *informativeText)
+ {
+-    if (err) {
+-        QEMU_Alert([NSString stringWithCString: error_get_pretty(err)
+-                                      encoding: NSASCIIStringEncoding]);
+-        error_free(err);
++    if (!err) {
++        return false;
+     }
++
++    error_report("ClassicMac media operation failed: %s",
++                 error_get_pretty(err));
++    NSAlert *alert = [[[NSAlert alloc] init] autorelease];
++    [alert setAlertStyle:NSAlertStyleWarning];
++    [alert setMessageText:message];
++    [alert setInformativeText:informativeText];
++    [alert addButtonWithTitle:@"OK"];
++    [alert runModal];
++    error_free(err);
++    return true;
+ }
+ 
+ /*
+@@ -1533,7 +1584,8 @@
+  ------------------------------------------------------
+ */
+ @interface QemuCocoaAppController : NSObject
+-                                       <NSWindowDelegate, NSApplicationDelegate>
++                                       <NSWindowDelegate, NSApplicationDelegate,
++                                        NSMenuDelegate>
+ {
+ }
+ - (void)doToggleFullScreen:(id)sender;
+@@ -1551,8 +1603,8 @@
+ - (void)powerDownQEMU:(id)sender;
+ - (void)ejectDeviceMedia:(id)sender;
+ - (void)changeDeviceMedia:(id)sender;
+-- (void)insertToolsCD:(id)sender;
+-- (void)ejectToolsCD:(id)sender;
++- (void)toggleToolsCD:(id)sender;
++- (void)refreshMediaMenuItems;
+ - (BOOL)verifyQuit;
+ - (void)openDocumentation:(NSString *)filename;
+ - (IBAction) do_about_menu_item: (id) sender;
+@@ -1669,7 +1721,7 @@
+ - (void)windowDidEnterFullScreen:(NSNotification *)notification
+ {
+     if (fullscreen_menu_item) {
+-        [fullscreen_menu_item setTitle:@"Exit Fullscreen"];
++        [fullscreen_menu_item setTitle:@"Exit Full Screen"];
+     }
+     /* Publish the final post-animation content frame. Intermediate resize
+      * notifications can still reflect the former titlebar-sized window. */
+@@ -1681,7 +1733,7 @@
+ - (void)windowDidExitFullScreen:(NSNotification *)notification
+ {
+     if (fullscreen_menu_item) {
+-        [fullscreen_menu_item setTitle:@"Enter Fullscreen"];
++        [fullscreen_menu_item setTitle:@"Enter Full Screen"];
+     }
+     [cocoaView applyTitleBarAppearance];
+     [cocoaView ungrabMouse];
+@@ -1781,9 +1833,9 @@
+     NSString *fullscreenTitle;
+ 
+     if (([[cocoaView window] styleMask] & NSWindowStyleMaskFullScreen) != 0) {
+-        fullscreenTitle = @"Exit Fullscreen";
++        fullscreenTitle = @"Exit Full Screen";
+     } else {
+-        fullscreenTitle = @"Enter Fullscreen";
++        fullscreenTitle = @"Enter Full Screen";
+     }
+     item = [[[NSMenuItem alloc] initWithTitle:fullscreenTitle
+                                        action:@selector(doToggleFullScreen:)
+@@ -1799,7 +1851,7 @@
+     [item setTarget:self];
+     [dockMenu addItem:item];
+ 
+-    item = [[[NSMenuItem alloc] initWithTitle:@"Resend Screen Resolution"
++    item = [[[NSMenuItem alloc] initWithTitle:@"Match Mac Screen to Window"
+                                        action:@selector(resendDisplayResolution:)
+                                 keyEquivalent:@""] autorelease];
+     [item setTarget:self];
+@@ -1954,105 +2006,132 @@
+     });
+ }
+ 
+-/* Ejects the media.
+- * Uses sender's tag to figure out the device to eject.
+- */
++/* Ejects the user-selected disc. */
+ - (void)ejectDeviceMedia:(id)sender
+ {
+-    NSString * drive;
+-    drive = [sender representedObject];
++    NSString *drive = [sender representedObject];
+     if(drive == nil) {
+         NSBeep();
+-        QEMU_Alert(@"Failed to find drive to eject!");
++        QEMU_Alert(@"The Mac's disc drive is unavailable.");
+         return;
+     }
+ 
+     __block Error *err = NULL;
+     with_bql(^{
+-        qmp_eject([drive cStringUsingEncoding: NSASCIIStringEncoding],
+-                  NULL, false, false, &err);
++        qmp_eject([drive UTF8String], NULL, true, true, &err);
+     });
+-    handleAnyDeviceErrors(err);
++    if (!classicmac_handle_media_error(err, @"The Disc Couldn't Be Ejected", @"The Mac's disc drive may be busy. Wait a moment, then try again.")) {
++        [disc_eject_menu_item setEnabled:NO];
++    }
+ }
+ 
+-/* Displays a dialog box asking the user to select an image file to load.
+- * Uses sender's represented object value to figure out which drive to use.
+- */
++/* Asks for a disc image and inserts it into the user-facing CD drive. */
+ - (void)changeDeviceMedia:(id)sender
+ {
+-    /* Find the drive name */
+-    NSString * drive;
+-    drive = [sender representedObject];
++    NSString *drive = [sender representedObject];
+     if(drive == nil) {
+         NSBeep();
+-        QEMU_Alert(@"Could not find drive!");
++        QEMU_Alert(@"The Mac's disc drive is unavailable.");
+         return;
+     }
+ 
+-    /* Display the file open dialog */
+-    NSOpenPanel * openPanel;
+-    openPanel = [NSOpenPanel openPanel];
+-    [openPanel setCanChooseFiles: YES];
+-    [openPanel setAllowsMultipleSelection: NO];
++    NSOpenPanel *openPanel = [NSOpenPanel openPanel];
++    [openPanel setCanChooseFiles:YES];
++    [openPanel setCanChooseDirectories:NO];
++    [openPanel setAllowsMultipleSelection:NO];
++    [openPanel setPrompt:@"Insert"];
++    [openPanel setMessage:@"Choose a disc image for the Mac."];
+     if([openPanel runModal] == NSModalResponseOK) {
+-        NSString * file = [[[openPanel URLs] objectAtIndex: 0] path];
++        NSString *file = [[[openPanel URLs] objectAtIndex:0] path];
+         if(file == nil) {
+             NSBeep();
+-            QEMU_Alert(@"Failed to convert URL to file path!");
++            QEMU_Alert(@"That disc image couldn't be opened.");
+             return;
+         }
+ 
+         __block Error *err = NULL;
+         with_bql(^{
+-            qmp_blockdev_change_medium([drive cStringUsingEncoding:
+-                                                  NSASCIIStringEncoding],
+-                                       NULL,
+-                                       [file cStringUsingEncoding:
+-                                                 NSASCIIStringEncoding],
+-                                       "raw",
+-                                       true, false,
+-                                       false, 0,
++            qmp_blockdev_change_medium([drive UTF8String], NULL,
++                                       [file fileSystemRepresentation], "raw",
++                                       true, true,
++                                       true,
++                                       BLOCKDEV_CHANGE_READ_ONLY_MODE_READ_ONLY,
+                                        &err);
+         });
+-        handleAnyDeviceErrors(err);
++        if (!classicmac_handle_media_error(err,
++                                           @"The Disc Couldn't Be Inserted", @"ClassicMac couldn't read the selected image, or the Mac's disc drive is busy. Check that the file is available, then try again.")) {
++            [disc_eject_menu_item setEnabled:YES];
++        }
+     }
+ }
+ 
+ /*
+- * ClassicMac: one-click insert/eject of the bundled Tools CD (guest
+- * additions: StuffIt Expander, Disk Copy, USB Overdrive, ...) into the
+- * dedicated "tools0" drive the host app always attaches. The app points at
+- * the image through the CLASSICMAC_TOOLS_CD environment variable.
++ * One stateful command inserts or ejects the bundled ClassicMac Tools disc.
++ * Both machine families keep a dedicated, removable CD tray present. Eject
++ * opens that tray; insert loads the bundled image back into the same drive.
+  */
+-- (void)insertToolsCD:(id)sender
++- (void)toggleToolsCD:(id)sender
+ {
+     const char *path = getenv(CLASSICMAC_TOOLS_CD_ENV);
+ 
+-    if (path == NULL) {
++    if (path == NULL || path[0] == '\0') {
+         NSBeep();
+-        QEMU_Alert(@"The Tools CD image is missing from this copy of ClassicMac.");
++        QEMU_Alert(@"ClassicMac Tools is missing from this copy of ClassicMac.");
+         return;
+     }
+ 
+     __block Error *err = NULL;
++    __block bool wasInserted = false;
+     with_bql(^{
+-        qmp_blockdev_change_medium(CLASSICMAC_TOOLS_DRIVE, NULL, path, "raw",
+-                                   true, false,
+-                                   false, 0,
+-                                   &err);
++        wasInserted = classicmac_tools_are_inserted();
++        if (wasInserted) {
++            qmp_eject(CLASSICMAC_TOOLS_DRIVE, NULL, true, true, &err);
++        } else {
++            qmp_blockdev_change_medium(
++                CLASSICMAC_TOOLS_DRIVE, NULL, path, "raw",
++                true, true,
++                true, BLOCKDEV_CHANGE_READ_ONLY_MODE_READ_ONLY,
++                &err);
++        }
+     });
+-    handleAnyDeviceErrors(err);
++
++    NSString *message = wasInserted ? @"ClassicMac Tools Couldn't Be Ejected"
++                                    : @"ClassicMac Tools Couldn't Be Inserted";
++    NSString *informativeText = wasInserted
++        ? @"The Mac's disc drive may be busy. Wait a moment, then try again."
++        : @"ClassicMac couldn't read its Tools disc image, or the Mac's disc drive is busy. Wait a moment, then try again.";
++    if (classicmac_handle_media_error(err, message, informativeText)) {
++        [self refreshMediaMenuItems];
++        return;
++    }
++    [self refreshMediaMenuItems];
+ }
+ 
+-- (void)ejectToolsCD:(id)sender
++- (void)refreshMediaMenuItems
+ {
+-    __block Error *err = NULL;
++    __block bool toolsInserted = false;
++    __block bool discInserted = false;
++    const char *discDrive = [classicmac_disc_drive UTF8String];
++
+     with_bql(^{
+-        qmp_eject(CLASSICMAC_TOOLS_DRIVE, NULL, false, false, &err);
++        if (tools_cd_menu_item) {
++            toolsInserted = classicmac_tools_are_inserted();
++        }
++        if (discDrive) {
++            discInserted = classicmac_drive_has_media(discDrive);
++        }
+     });
+-    handleAnyDeviceErrors(err);
++
++    [tools_cd_menu_item setTitle:(toolsInserted ?
++        @"Eject “ClassicMac Tools”" : @"Insert “ClassicMac Tools”")];
++    [disc_eject_menu_item setEnabled:discInserted];
+ }
+ 
++- (void)menuWillOpen:(NSMenu *)menu
++{
++    [self refreshMediaMenuItems];
++}
++
+ /* Verifies if the user really wants to quit */
+ - (BOOL)verifyQuit
+ {
+@@ -2162,9 +2238,10 @@
+     [[NSApp mainMenu] addItem:menuItem];
+     [NSApp performSelector:@selector(setAppleMenu:) withObject:menu]; // Workaround (this method is private since 10.4+)
+ 
+-    // Machine menu
+-    menu = [[NSMenu alloc] initWithTitle: @"Machine"];
++    // Mac menu: controls for the running classic Macintosh.
++    menu = [[NSMenu alloc] initWithTitle: @"Mac"];
+     [menu setAutoenablesItems: NO];
++    [menu setDelegate:(id<NSMenuDelegate>)[NSApp delegate]];
+     [menu addItem: [[[NSMenuItem alloc] initWithTitle: @"Pause" action: @selector(pauseQEMU:) keyEquivalent: @""] autorelease]];
+     menuItem = [[[NSMenuItem alloc] initWithTitle: @"Resume" action: @selector(resumeQEMU:) keyEquivalent: @""] autorelease];
+     [menu addItem: menuItem];
+@@ -2172,16 +2249,29 @@
+     [menu addItem: [NSMenuItem separatorItem]];
+     [menu addItem: [[[NSMenuItem alloc] initWithTitle: @"Restart" action: @selector(restartQEMU:) keyEquivalent: @""] autorelease]];
+     [menu addItem: [[[NSMenuItem alloc] initWithTitle: @"Shut Down" action: @selector(powerDownQEMU:) keyEquivalent: @""] autorelease]];
+-    /*
+-     * ClassicMac: quick insert/eject of the bundled Tools CD, shown when the
+-     * host app told us where the image lives.
+-     */
++    /* One stateful command for the bundled tools disc. Its title is refreshed
++     * from the real drive state each time the menu opens. */
+     if (getenv(CLASSICMAC_TOOLS_CD_ENV) != NULL) {
+         [menu addItem: [NSMenuItem separatorItem]];
+-        [menu addItem: [[[NSMenuItem alloc] initWithTitle: @"Insert Tools CD" action: @selector(insertToolsCD:) keyEquivalent: @""] autorelease]];
+-        [menu addItem: [[[NSMenuItem alloc] initWithTitle: @"Eject Tools CD" action: @selector(ejectToolsCD:) keyEquivalent: @""] autorelease]];
++        tools_cd_menu_item = [[[NSMenuItem alloc]
++            initWithTitle: @"Insert “ClassicMac Tools”"
++                    action: @selector(toggleToolsCD:)
++             keyEquivalent: @""] autorelease];
++        [menu addItem:tools_cd_menu_item];
+     }
+-    menuItem = [[[NSMenuItem alloc] initWithTitle: @"Machine" action:nil keyEquivalent:@""] autorelease];
++
++    /* Keep classic input conveniences in the Mac menu, separate from screen
++     * presentation options. */
++    [menu addItem: [NSMenuItem separatorItem]];
++    input_helpers_menu_item = [[[NSMenuItem alloc]
++        initWithTitle:@"Secondary Click and Scrolling"
++                action:@selector(toggleInputHelpers:)
++         keyEquivalent:@""] autorelease];
++    [input_helpers_menu_item setState:(right_click_ctrl || scroll_keys) ?
++        NSControlStateValueOn : NSControlStateValueOff];
++    [menu addItem:input_helpers_menu_item];
++
++    menuItem = [[[NSMenuItem alloc] initWithTitle: @"Mac" action:nil keyEquivalent:@""] autorelease];
+     [menuItem setSubmenu:menu];
+     [[NSApp mainMenu] addItem:menuItem];
+ 
+@@ -2194,7 +2284,7 @@
+      * a Command shortcut would be swallowed by the guest there, which made
+      * fullscreen hard to leave).
+      */
+-    menuItem = [[[NSMenuItem alloc] initWithTitle:@"Enter Fullscreen" action:@selector(doToggleFullScreen:) keyEquivalent:@"f"] autorelease]; // Fullscreen
++    menuItem = [[[NSMenuItem alloc] initWithTitle:@"Enter Full Screen" action:@selector(doToggleFullScreen:) keyEquivalent:@"f"] autorelease];
+     [menuItem setKeyEquivalentModifierMask:(NSEventModifierFlagControl|NSEventModifierFlagOption)];
+     fullscreen_menu_item = menuItem;
+     [menu addItem: menuItem];
+@@ -2204,29 +2294,15 @@
+     [menuItem setKeyEquivalentModifierMask:(NSEventModifierFlagControl|NSEventModifierFlagOption)];
+     titlebar_menu_item = menuItem;
+     [menu addItem: menuItem];
+-    /* ClassicMac: ask the guest to switch to the window's resolution again,
+-     * for when it missed the request that accompanied the last resize. */
+-    menuItem = [[[NSMenuItem alloc] initWithTitle:@"Resend Screen Resolution" action:@selector(resendDisplayResolution:) keyEquivalent:@"r"] autorelease];
++    /* Ask the classic Mac to adopt the window's current drawable size. */
++    menuItem = [[[NSMenuItem alloc] initWithTitle:@"Match Mac Screen to Window" action:@selector(resendDisplayResolution:) keyEquivalent:@"r"] autorelease];
+     [menuItem setKeyEquivalentModifierMask:(NSEventModifierFlagControl|NSEventModifierFlagOption)];
+     [menu addItem: menuItem];
+-    menuItem = [[[NSMenuItem alloc] initWithTitle:@"Zoom To Fit" action:@selector(zoomToFit:) keyEquivalent:@""] autorelease];
+-    [menuItem setState: [[cocoaView window] styleMask] & NSWindowStyleMaskResizable ? NSControlStateValueOn : NSControlStateValueOff];
+-    [menu addItem: menuItem];
+-    menuItem = [[[NSMenuItem alloc] initWithTitle:@"Zoom Interpolation" action:@selector(toggleZoomInterpolation:) keyEquivalent:@""] autorelease];
++
++    [menu addItem: [NSMenuItem separatorItem]];
++    menuItem = [[[NSMenuItem alloc] initWithTitle:@"Smooth Scaling" action:@selector(toggleZoomInterpolation:) keyEquivalent:@""] autorelease];
+     [menuItem setState: zoom_interpolation == kCGInterpolationLow ? NSControlStateValueOn : NSControlStateValueOff];
+     [menu addItem: menuItem];
+-    /*
+-     * ClassicMac: live toggle of the classic input helpers, mirroring the
+-     * "Right-click & scroll wheel helpers" per-VM setting in the host app.
+-     */
+-    [menu addItem: [NSMenuItem separatorItem]];
+-    menuItem = [[[NSMenuItem alloc] initWithTitle:@"Right-Click & Scroll Wheel Helpers" action:@selector(toggleInputHelpers:) keyEquivalent:@""] autorelease];
+-    if (right_click_ctrl || scroll_keys) {
+-        [menuItem setState: NSControlStateValueOn];
+-    } else {
+-        [menuItem setState: NSControlStateValueOff];
+-    }
+-    [menu addItem: menuItem];
+     menuItem = [[[NSMenuItem alloc] initWithTitle:@"View" action:nil keyEquivalent:@""] autorelease];
+     [menuItem setSubmenu:menu];
+     [[NSApp mainMenu] addItem:menuItem];
+@@ -2250,115 +2326,54 @@
+      */
+ }
+ 
+-/* Returns a name for a given console */
+-static NSString * getConsoleName(QemuConsole * console)
+-{
+-    g_autofree char *label = qemu_console_get_label(console);
+-
+-    return [NSString stringWithUTF8String:label];
+-}
+-
+-/* Add an entry to the View menu for each console */
+-static void add_console_menu_entries(void)
+-{
+-    NSMenu *menu;
+-    NSMenuItem *menuItem;
+-    int index = 0;
+-
+-    menu = [[[NSApp mainMenu] itemWithTitle:@"View"] submenu];
+-
+-    [menu addItem:[NSMenuItem separatorItem]];
+-
+-    while (qemu_console_lookup_by_index(index) != NULL) {
+-        menuItem = [[[NSMenuItem alloc] initWithTitle: getConsoleName(qemu_console_lookup_by_index(index))
+-                                               action: @selector(displayConsole:) keyEquivalent: @""] autorelease];
+-        [menuItem setTag: index];
+-        [menu addItem: menuItem];
+-        index++;
+-    }
+-}
+-
+-/* Make menu items for all removable devices.
+- * Each device is given an 'Eject' and 'Change' menu item.
+- */
++/* Add one native Disc submenu for the user-selected CD drive. Internal
++ * consoles, floppy controllers, and backend identifiers stay out of the UI. */
+ static void addRemovableDevicesMenuItems(void)
+ {
+-    NSMenu *menu;
+-    NSMenuItem *menuItem;
+-    BlockInfoList *currentDevice, *pointerToFree;
+-    NSString *deviceName;
++    NSMenu *menu = [[[NSApp mainMenu] itemWithTitle:@"Mac"] submenu];
++    BlockInfoList *currentDevice = qmp_query_block(false, false, NULL);
++    BlockInfoList *pointerToFree = currentDevice;
+ 
+-    currentDevice = qmp_query_block(false, false, NULL);
+-    pointerToFree = currentDevice;
++    while (currentDevice) {
++        const char *rawName = currentDevice->value->device;
++        if (currentDevice->value->removable &&
++            rawName &&
++            strcmp(rawName, CLASSICMAC_DISC_DRIVE) == 0) {
++            classicmac_disc_drive = [[NSString stringWithUTF8String:rawName]
++                                      retain];
+ 
+-    menu = [[[NSApp mainMenu] itemWithTitle:@"Machine"] submenu];
++            NSMenu *discMenu = [[[NSMenu alloc] initWithTitle:@"Disc"]
++                                autorelease];
++            [discMenu setAutoenablesItems:NO];
++            NSMenuItem *insertItem = [[[NSMenuItem alloc]
++                initWithTitle:@"Insert Disc Image…"
++                        action:@selector(changeDeviceMedia:)
++                 keyEquivalent:@""] autorelease];
++            [insertItem setRepresentedObject:classicmac_disc_drive];
++            [discMenu addItem:insertItem];
+ 
+-    // Add a separator between related groups of menu items
+-    [menu addItem:[NSMenuItem separatorItem]];
++            disc_eject_menu_item = [[[NSMenuItem alloc]
++                initWithTitle:@"Eject Disc"
++                        action:@selector(ejectDeviceMedia:)
++                 keyEquivalent:@""] autorelease];
++            [disc_eject_menu_item setRepresentedObject:classicmac_disc_drive];
++            [disc_eject_menu_item setEnabled:
++                currentDevice->value->inserted != NULL];
++            [discMenu addItem:disc_eject_menu_item];
+ 
+-    // Set the attributes to the "Removable Media" menu item
+-    NSString *titleString = @"Removable Media";
+-    NSMutableAttributedString *attString=[[NSMutableAttributedString alloc] initWithString:titleString];
+-    NSColor *newColor = [NSColor blackColor];
+-    NSFontManager *fontManager = [NSFontManager sharedFontManager];
+-    NSFont *font = [fontManager fontWithFamily:@"Helvetica"
+-                                          traits:NSBoldFontMask|NSItalicFontMask
+-                                          weight:0
+-                                            size:14];
+-    [attString addAttribute:NSFontAttributeName value:font range:NSMakeRange(0, [titleString length])];
+-    [attString addAttribute:NSForegroundColorAttributeName value:newColor range:NSMakeRange(0, [titleString length])];
+-    [attString addAttribute:NSUnderlineStyleAttributeName value:[NSNumber numberWithInt: 1] range:NSMakeRange(0, [titleString length])];
+-
+-    // Add the "Removable Media" menu item
+-    menuItem = [NSMenuItem new];
+-    [menuItem setAttributedTitle: attString];
+-    [menuItem setEnabled: NO];
+-    [menu addItem: menuItem];
+-
+-    /* Loop through all the block devices in the emulator */
+-    while (currentDevice) {
+-        /* ClassicMac: the Tools CD drive has its own friendly Insert/Eject
+-         * items in this menu; skip its raw Change/Eject entries. */
+-        if (getenv(CLASSICMAC_TOOLS_CD_ENV) != NULL &&
+-            currentDevice->value->device != NULL &&
+-            strcmp(currentDevice->value->device, CLASSICMAC_TOOLS_DRIVE) == 0) {
+-            currentDevice = currentDevice->next;
+-            continue;
+-        }
+-
+-        deviceName = [[NSString stringWithFormat: @"%s", currentDevice->value->device] retain];
+-
+-        /* ClassicMac: show Mac-friendly drive names instead of raw QEMU
+-         * block-device ids ("cd0", "ide1-cd0", "floppy0"). The raw id still
+-         * rides along in representedObject for the QMP calls. */
+-        const char *rawName = currentDevice->value->device;
+-        const char *displayName = rawName;
+-        if (rawName != NULL) {
+-            if (strstr(rawName, "cd") != NULL) {
+-                displayName = "CD-ROM";
+-            } else if (strstr(rawName, "floppy") != NULL ||
+-                       strncmp(rawName, "fd", 2) == 0) {
+-                displayName = "Floppy";
+-            }
+-        }
+-
+-        if(currentDevice->value->removable) {
+-            menuItem = [[NSMenuItem alloc] initWithTitle: [NSString stringWithFormat: @"Change %s Image\u2026", displayName]
+-                                                  action: @selector(changeDeviceMedia:)
+-                                           keyEquivalent: @""];
+-            [menu addItem: menuItem];
+-            [menuItem setRepresentedObject: deviceName];
+-            [menuItem autorelease];
++            NSMenuItem *discItem = [[[NSMenuItem alloc]
++                initWithTitle:@"Disc" action:nil keyEquivalent:@""] autorelease];
++            [discItem setSubmenu:discMenu];
+ 
+-            menuItem = [[NSMenuItem alloc] initWithTitle: [NSString stringWithFormat: @"Eject %s", displayName]
+-                                                  action: @selector(ejectDeviceMedia:)
+-                                           keyEquivalent: @""];
+-            [menu addItem: menuItem];
+-            [menuItem setRepresentedObject: deviceName];
+-            [menuItem autorelease];
++            NSInteger inputIndex = [menu indexOfItem:input_helpers_menu_item];
++            NSInteger insertionIndex = inputIndex > 0 ? inputIndex - 1
++                                                       : [menu numberOfItems];
++            [menu insertItem:discItem atIndex:insertionIndex];
++            break;
+         }
+         currentDevice = currentDevice->next;
+     }
++
+     qapi_free_BlockInfoList(pointerToFree);
+ }
+ 
+@@ -2562,6 +2577,10 @@
+ 
+     [QemuApplication sharedApplication];
+ 
++    /* A running classic Mac has one screen window, so opt out of AppKit's
++     * automatic tab commands before that window is created. */
++    [NSWindow setAllowsAutomaticWindowTabbing:NO];
++
+     /*
+      * ClassicMac: make sure the Dock shows the machine icon from the wrapping
+      * helper app bundle even when the process was spawned directly.
+@@ -2614,13 +2633,12 @@
+ 
+     create_initial_menus();
+     /*
+-     * Create the menu entries which depend on QEMU state (for consoles
+-     * and removable devices). These make calls back into QEMU functions,
++     * Create the Disc submenu when a user-facing CD drive is present. This
++     * makes calls back into QEMU functions,
+      * which is OK because at this point we know that the second thread
+      * holds the BQL and is synchronously waiting for us to
+      * finish.
+      */
+-    add_console_menu_entries();
+     addRemovableDevicesMenuItems();
+ 
+     dcl.con = qemu_console_lookup_default();

--- a/scripts/build-guest-cd.sh
+++ b/scripts/build-guest-cd.sh
@@ -144,8 +144,8 @@ USB Overdrive 1.4  (Power Mac only, Mac OS 8.5 - 9.2)
    and then.
 
    IMPORTANT: after installing USB Overdrive, turn OFF
-   "Right-Click & Scroll Wheel Helpers" in the machine
-   window's View menu (or in the machine's settings in
+   "Secondary Click and Scrolling" in the machine
+   window's Mac menu (or in the machine's settings in
    ClassicMac), so clicks and scrolling are not doubled up.
 
 On a Quadra (System 7 through Mac OS 8.1), skip USB Overdrive -

--- a/scripts/build-qemu.sh
+++ b/scripts/build-qemu.sh
@@ -173,6 +173,10 @@ git -C "$QEMU_DIR" apply "$ROOT_DIR/cocoaui/fullscreen-resolution-menu.patch" ||
 # Control-Option-T borderless-window toggle plus final-frame reporting after
 # native fullscreen transitions, so the guest uses the complete drawable area.
 git -C "$QEMU_DIR" apply "$ROOT_DIR/cocoaui/window-presentation.patch" || die "Failed to apply ClassicMac window presentation patch"
+# Final Mac-native menu pass: a state-aware Tools command, friendly Disc
+# submenu and errors, focused View controls, and no raw emulator consoles or
+# removable-device identifiers in the menu bar.
+git -C "$QEMU_DIR" apply "$ROOT_DIR/cocoaui/mac-native-menus.patch" || die "Failed to apply ClassicMac native menus patch"
 # Apple Sound Chip: always feed the audio backend silence when idle so a live
 # backend (CoreAudio) never replays stale ring-buffer content as a hum/buzz.
 git -C "$QEMU_DIR" apply "$QFB_DIR/asc-silence.patch" || die "Failed to apply asc silence patch"

--- a/scripts/bundle-qemu.sh
+++ b/scripts/bundle-qemu.sh
@@ -38,7 +38,7 @@ HELPERS_DIR="$CONTENTS/Helpers"
 QUADRA_APP="$HELPERS_DIR/Quadra 800.app"
 PPC_APP="$HELPERS_DIR/Power Mac G4.app"
 
-APP_VERSION="${APP_VERSION:-1.3.0}"
+APP_VERSION="${APP_VERSION:-1.4.0}"
 BUNDLE_ID="com.classicmac.emulator"
 
 log() { printf '\n==> %s\n' "$*"; }


### PR DESCRIPTION
## What changed

- Replaces the running machine’s QEMU-facing menus with focused **Mac** and **View** menus.
- Adds state-aware insert/eject controls for ClassicMac Tools and a permanent user-facing Disc tray.
- Moves Power Mac optical media onto the correct IDE channel and keeps fixed Disc/Tools positions on Quadra.
- Preserves Power Mac startup-CD boot priority by swapping the optical positions only during disc startup.
- Adds clearer settings copy, runtime media errors, release documentation, and 1.4.0 version metadata.

## Why

The previous Tools control changed QEMU’s backend successfully, but Mac OS 9 did not see the disc because the Tools drive was attached beside the hard disk instead of as a real optical tray. The running-machine menu bar also exposed raw QEMU consoles, backend identifiers, and developer controls that did not belong in a Mac-focused app.

## User impact

ClassicMac Tools and other disc images can now be inserted or ejected while either machine is running, including when the user-disc tray started empty. Menu labels and errors are now concise, Mac-themed, and state-aware.

## Validation

- Live Tools and user-disc insert/eject/reinsert cycles in Finder on Mac OS 9 and Mac OS 8.1
- Power Mac startup-disc boot-priority probe against the real Mac OS 9 CD
- Complete patched QEMU build for m68k and PPC
- 13 Swift tests, 0 failures
- Patch-chain and shell-syntax checks
- Developer ID bundle signing and deep signature verification