### PR TITLE
Release 1.6.0 with guided setup and UI polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 1.6.0 — 2026-08-05
+
+### Added
+
+- **A guided new-machine setup.** Creating a Mac is now a focused three-step
+  flow for the model and file location, hardware and display, then installation
+  media and folder sharing. A final summary makes the important choices easy to
+  verify before the machine is created.
+- **Safer immediate shutdown.** ClassicMac now warns that forcing off a running
+  machine can lose unsaved guest work and recommends shutting down from inside
+  Mac OS when possible.
+
+### Changed
+
+- **The machine library opens directly to an existing Mac.** ClassicMac selects
+  the first available machine at launch and keeps a nearby machine selected
+  after one is removed, instead of falling back to first-run messaging.
+- **Machine details are easier to scan.** The header now summarizes memory,
+  disk size, and display resolution, while the saved-screen preview is more
+  compact so display settings remain visible in a standard-size window.
+- **Display and configuration validation is consistent.** Names, resolutions,
+  color depths, and model-specific limits are normalized in one place for both
+  newly created and older machine files.
+
+### Fixed
+
+- Copying an installation disc whose filename matches existing media now
+  creates a unique copy instead of silently reusing the older file.
+- Turning off custom or enhanced video now keeps the stored resolution and the
+  visible preset in sync.
+- The new-machine window remains open when disk creation fails so the selected
+  settings are not lost.
+
 ## 1.5.0 — 2026-07-18
 
 ### Added

--- a/app/Sources/ClassicMac/ClassicMacApp.swift
+++ b/app/Sources/ClassicMac/ClassicMacApp.swift
@@ -101,7 +101,7 @@ private struct MachineCommands: View {
 
         Button("Shut Down") {
             if let vm = vm {
-                manager.stop(vm.id)
+                manager.requestStop(vm.id)
             }
         }
         .disabled(!running)

--- a/app/Sources/ClassicMac/ContentView.swift
+++ b/app/Sources/ClassicMac/ContentView.swift
@@ -14,7 +14,9 @@ struct ContentView: View {
             NewVMSheet { newConfig in
                 if let created = store.createVM(newConfig) {
                     store.selectedID = created.id
+                    return true
                 }
+                return false
             }
         }
         .alert(
@@ -34,6 +36,20 @@ struct ContentView: View {
         } message: { error in
             Text(error.message)
         }
+        .confirmationDialog(
+            "Shut Down \(pendingStopName)?",
+            isPresented: stopConfirmationBinding,
+            titleVisibility: .visible
+        ) {
+            Button("Shut Down Now", role: .destructive) {
+                manager.confirmStop()
+            }
+            Button("Cancel", role: .cancel) {
+                manager.cancelStop()
+            }
+        } message: {
+            Text("This turns the machine off immediately and may lose unsaved work. When possible, shut down from inside Mac OS instead.")
+        }
     }
 
     private var currentError: AppError? {
@@ -46,6 +62,25 @@ struct ContentView: View {
     private func clearErrors() {
         store.lastError = nil
         manager.lastError = nil
+    }
+
+    private var pendingStopName: String {
+        guard let id = manager.pendingStopID,
+              let vm = store.vms.first(where: { $0.id == id }) else {
+            return "this machine"
+        }
+        return "\u{201C}\(vm.name)\u{201D}"
+    }
+
+    private var stopConfirmationBinding: Binding<Bool> {
+        Binding(
+            get: { manager.pendingStopID != nil },
+            set: { isPresented in
+                if !isPresented {
+                    manager.cancelStop()
+                }
+            }
+        )
     }
 
     private var sidebar: some View {
@@ -99,7 +134,7 @@ struct ContentView: View {
         let running = manager.isRunning(vm.id)
         if running {
             Button("Shut Down") {
-                manager.stop(vm.id)
+                manager.requestStop(vm.id)
             }
         } else {
             Button("Start") {
@@ -137,7 +172,11 @@ struct ContentView: View {
             VMDetailView(vmID: id)
                 .id(id)
         } else {
-            EmptyStateView(showingNewVM: $store.isPresentingNewVM)
+            EmptyStateView(
+                hasMachines: !store.vms.isEmpty,
+                showingNewVM: $store.isPresentingNewVM,
+                openExisting: store.presentOpenPanel
+            )
         }
     }
 
@@ -191,7 +230,9 @@ struct VMRow: View {
 }
 
 struct EmptyStateView: View {
+    let hasMachines: Bool
     @Binding var showingNewVM: Bool
+    let openExisting: () -> Void
 
     var body: some View {
         VStack(spacing: 12) {
@@ -200,23 +241,37 @@ struct EmptyStateView: View {
                 MachineBadgeView(family: .powerMacG4, size: 76)
             }
             .padding(.bottom, 12)
-            Text("Welcome to ClassicMac")
+            Text(hasMachines ? "Choose a Mac" : "Welcome to ClassicMac")
                 .font(.largeTitle.bold())
-            Text("Run the classic Mac OS you grew up with. Create a Quadra 800 for System 7 through Mac OS 8.1, or a Power Mac G4 for Mac OS 8.5 through 9.2.")
+            Text(description)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 420)
-            Button {
-                showingNewVM = true
-            } label: {
-                Label("Create Your First Mac", systemImage: "plus")
-                    .padding(.horizontal, 4)
+            HStack(spacing: 10) {
+                Button {
+                    showingNewVM = true
+                } label: {
+                    Label(hasMachines ? "New Machine" : "Create Your First Mac", systemImage: "plus")
+                        .padding(.horizontal, 4)
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button(action: openExisting) {
+                    Label("Open Machine", systemImage: "folder")
+                }
+                .buttonStyle(.bordered)
             }
             .controlSize(.large)
-            .buttonStyle(.borderedProminent)
             .padding(.top, 8)
         }
         .padding(40)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var description: String {
+        if hasMachines {
+            return "Select a machine in the sidebar, or create another classic Macintosh."
+        }
+        return "Run System 7 through Mac OS 9 on a Quadra 800 or Power Mac G4. Each machine is a portable file you can keep anywhere."
     }
 }

--- a/app/Sources/ClassicMac/NewVMSheet.swift
+++ b/app/Sources/ClassicMac/NewVMSheet.swift
@@ -2,24 +2,25 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct NewVMSheet: View {
-    var onCreate: (VMConfig) -> Void
+    var onCreate: (VMConfig) -> Bool
 
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var store: VMStore
 
+    @State private var step: SetupStep = .machine
     @State private var family: MachineFamily = .quadra800
     @State private var name = MachineFamily.quadra800.defaultName
     @State private var ramMB = MachineFamily.quadra800.defaultRAMMB
     @State private var diskSizeGB = MachineFamily.quadra800.defaultDiskSizeGB
     @State private var useEnhancedFramebuffer = true
-    @State private var resolution = ResolutionPreset.all[2]
+    @State private var resolution = ResolutionPreset.recommended
     @State private var depth = ColorDepth.thousands
     @State private var customResolution = false
-    @State private var customWidth = 1024
-    @State private var customHeight = 768
+    @State private var customWidth = ResolutionPreset.recommended.width
+    @State private var customHeight = ResolutionPreset.recommended.height
     @State private var sound = true
 
     @State private var saveFolder: URL = AppPaths.defaultLibraryDir
-
     @State private var isoURL: URL?
     @State private var copyISOIntoLibrary = true
     @State private var sharedFolderURL: URL?
@@ -32,11 +33,11 @@ struct NewVMSheet: View {
         VStack(spacing: 0) {
             header
             Divider()
-            form
+            stepContent
             Divider()
             footer
         }
-        .frame(width: 560)
+        .frame(width: 620, height: 620)
         .overlay {
             if working {
                 workingOverlay
@@ -45,90 +46,135 @@ struct NewVMSheet: View {
     }
 
     private var header: some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading) {
-                Text("New Machine")
-                    .font(.headline)
-                Text("Set up a classic Macintosh.")
-                    .font(.subheadline)
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("New Machine")
+                        .font(.title2.bold())
+                    Text(step.subtitle)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text("Step \(step.rawValue + 1) of \(SetupStep.allCases.count)")
+                    .font(.caption.weight(.medium))
                     .foregroundStyle(.secondary)
             }
-            Spacer()
+
+            HStack(spacing: 8) {
+                ForEach(SetupStep.allCases) { item in
+                    Button {
+                        step = item
+                    } label: {
+                        Label(item.title, systemImage: item.systemImage)
+                            .font(.caption.weight(.semibold))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 7)
+                            .foregroundStyle(step == item ? Color.accentColor : Color.secondary)
+                            .background(
+                                step == item ? Color.accentColor.opacity(0.12) : Color.clear,
+                                in: Capsule()
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(item.rawValue > step.rawValue && !hasValidName)
+                }
+            }
         }
-        .padding(20)
+        .padding(.horizontal, 24)
+        .padding(.vertical, 20)
     }
 
-    private var form: some View {
+    @ViewBuilder
+    private var stepContent: some View {
+        switch step {
+        case .machine:
+            machineForm
+        case .hardware:
+            hardwareForm
+        case .media:
+            mediaForm
+        }
+    }
+
+    private var machineForm: some View {
         Form {
-            Section {
+            Section("Mac model") {
                 HStack(spacing: 12) {
-                    ForEach(MachineFamily.allCases) { f in
-                        MachineTile(family: f, selected: family == f) {
-                            family = f
+                    ForEach(MachineFamily.allCases) { candidate in
+                        MachineTile(family: candidate, selected: family == candidate) {
+                            family = candidate
                         }
                     }
                 }
                 .listRowBackground(Color.clear)
                 .listRowInsets(EdgeInsets())
-                TextField("Name", text: $name)
             }
 
-            Section("Location") {
+            Section {
+                TextField("Name", text: $name, prompt: Text(family.defaultName))
+
                 LabeledContent("Save in") {
-                    Text(saveFolder.path)
+                    Text(saveFolder.path(percentEncoded: false))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                         .truncationMode(.middle)
+                        .help(saveFolder.path(percentEncoded: false))
                 }
-                Button("Choose Folder...") {
+                Button("Choose Folder\u{2026}") {
                     chooseSaveFolder()
                 }
-                Text("Creates \u{201C}\(bundleFileName)\u{201D}, a self-contained machine file you can move anywhere.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+            } header: {
+                Text("Machine file")
+            } footer: {
+                Text("Creates \u{201C}\(bundleFileName)\u{201D}, a portable machine containing its settings and hard disk.")
             }
+        }
+        .formStyle(.grouped)
+        .onChange(of: family) { _, newFamily in
+            applyFamilyDefaults(newFamily)
+        }
+    }
 
-            Section("Hardware") {
+    private var hardwareForm: some View {
+        Form {
+            Section {
                 Picker("Memory", selection: $ramMB) {
                     ForEach(family.ramPresets, id: \.self) { mb in
                         Text("\(mb) MB").tag(mb)
                     }
                 }
-                Picker("Hard disk size", selection: $diskSizeGB) {
+                Picker("Hard disk", selection: $diskSizeGB) {
                     ForEach(family.diskSizePresets, id: \.self) { gb in
                         Text("\(gb) GB").tag(gb)
                     }
                 }
                 Toggle("Sound", isOn: $sound)
+            } header: {
+                Label("Hardware", systemImage: "memorychip")
+            } footer: {
                 if family == .powerMacG4 {
-                    Text("Mac OS 9 needs less than 1 GB of memory for stable sound; the presets stop at 896 MB.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    Text("Mac OS 9 is most stable with less than 1 GB of memory, so presets stop at 896 MB.")
                 }
             }
 
-            Section("Display") {
+            Section {
                 if family.supportsEnhancedFramebuffer {
-                    Toggle("Enhanced video card", isOn: $useEnhancedFramebuffer)
-                    Toggle("Custom resolution", isOn: $customResolution)
-                        .disabled(!useEnhancedFramebuffer)
-                } else if family.supportsCustomResolution {
-                    Toggle("Custom resolution", isOn: $customResolution)
-                }
-                if customResolution && family.supportsCustomResolution {
-                    HStack(spacing: 8) {
-                        TextField("Width", value: $customWidth, format: .number)
-                            .frame(width: 76)
-                            .multilineTextAlignment(.trailing)
-                        Text("x")
-                            .foregroundStyle(.secondary)
-                        TextField("Height", value: $customHeight, format: .number)
-                            .frame(width: 76)
-                            .multilineTextAlignment(.trailing)
-                        Button("Match Display") {
-                            matchMainDisplay()
+                    Toggle(isOn: $useEnhancedFramebuffer) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Enhanced video card")
+                            Text("Flexible sizes and richer color modes")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
                     }
+                }
+
+                Toggle("Custom resolution", isOn: $customResolution)
+                    .disabled(family.supportsEnhancedFramebuffer && !useEnhancedFramebuffer)
+
+                if customResolution {
+                    resolutionFields
                 } else {
                     Picker("Resolution", selection: $resolution) {
                         ForEach(ResolutionPreset.all) { preset in
@@ -136,108 +182,185 @@ struct NewVMSheet: View {
                         }
                     }
                 }
+
                 if family.supportsEnhancedFramebuffer {
-                    Picker("Color depth", selection: $depth) {
-                        ForEach(availableDepths) { d in
-                            Text(d.label).tag(d)
+                    Picker("Colors", selection: $depth) {
+                        ForEach(availableDepths) { candidate in
+                            Text(candidate.label).tag(candidate)
                         }
                     }
                 } else {
-                    Text("The Power Mac display starts at millions of colors. Once Mac OS is running you can drag the window to any size, or pick any depth from Black & White up to millions in the Monitors control panel.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    LabeledContent("Colors") {
+                        Text("Millions")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } header: {
+                Label("Display", systemImage: "display")
+            } footer: {
+                Text(displayFooter)
+            }
+        }
+        .formStyle(.grouped)
+        .onChange(of: useEnhancedFramebuffer) { _, isEnabled in
+            if !isEnabled {
+                customResolution = false
+            }
+            clampDepth()
+        }
+        .onChange(of: resolution) { clampDepth() }
+        .onChange(of: customWidth) { clampDepth() }
+    }
+
+    private var resolutionFields: some View {
+        LabeledContent("Size") {
+            HStack(spacing: 8) {
+                TextField(
+                    "Width",
+                    value: bounded($customWidth, minimum: VMConfig.minWidth, maximum: VMConfig.maxWidth),
+                    format: .number
+                )
+                .frame(width: 76)
+                .multilineTextAlignment(.trailing)
+                Text("\u{00D7}")
+                    .foregroundStyle(.secondary)
+                TextField(
+                    "Height",
+                    value: bounded($customHeight, minimum: VMConfig.minHeight, maximum: VMConfig.maxHeight),
+                    format: .number
+                )
+                .frame(width: 76)
+                .multilineTextAlignment(.trailing)
+                Button("Match Display") {
+                    matchMainDisplay()
                 }
             }
+        }
+    }
 
-            Section("Installation") {
-                if let isoURL = isoURL {
-                    LabeledContent("Install CD") {
+    private var mediaForm: some View {
+        Form {
+            Section {
+                if let isoURL {
+                    LabeledContent("Disc") {
                         Text(isoURL.lastPathComponent)
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                             .truncationMode(.middle)
+                            .help(isoURL.path(percentEncoded: false))
                     }
-                    Toggle("Keep a copy of the disc in ClassicMac", isOn: $copyISOIntoLibrary)
-                    Button("Choose a different disc...") {
-                        chooseISO()
+                    Toggle("Keep a copy in ClassicMac", isOn: $copyISOIntoLibrary)
+                    HStack {
+                        Button("Choose Another\u{2026}") {
+                            chooseISO()
+                        }
+                        Button("Remove", role: .destructive) {
+                            self.isoURL = nil
+                        }
                     }
                 } else {
                     Button("Choose Install Disc\u{2026}") {
                         chooseISO()
                     }
-                    Text("The Mac starts up from this disc so you can install Mac OS.")
+                    Text("Optional. You can insert a disc from the machine settings later.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+            } header: {
+                Label("Installation", systemImage: "opticaldiscdrive")
+            } footer: {
+                if isoURL != nil {
+                    Text("The new Mac will start from this disc so you can install Mac OS.")
+                }
             }
 
-            if family.supportsSharedFolder {
-                Section("Shared Folder") {
-                    if let sharedFolderURL = sharedFolderURL {
-                        LabeledContent("Folder") {
-                            Text(sharedFolderURL.lastPathComponent)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                        }
-                        Button("Remove") {
-                            self.sharedFolderURL = nil
-                        }
-                    } else {
-                        Button("Share a Folder from My Mac...") {
+            Section {
+                if let sharedFolderURL {
+                    LabeledContent("Folder") {
+                        Text(sharedFolderURL.lastPathComponent)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .help(sharedFolderURL.path(percentEncoded: false))
+                    }
+                    HStack {
+                        Button("Choose Another\u{2026}") {
                             chooseSharedFolder()
                         }
-                        Text("Optional. The folder appears as a disk on the Mac desktop.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                        Button("Stop Sharing", role: .destructive) {
+                            self.sharedFolderURL = nil
+                        }
                     }
+                } else {
+                    Button("Choose Folder to Share\u{2026}") {
+                        chooseSharedFolder()
+                    }
+                    Text("Optional. The folder appears as a disk on the classic Mac desktop.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
+            } header: {
+                Label("Shared Folder", systemImage: "folder.badge.person.crop")
+            }
+
+            Section {
+                LabeledContent("Machine") {
+                    Text(family.label)
+                }
+                LabeledContent("Hardware") {
+                    Text("\(ramMB) MB memory \u{2022} \(diskSizeGB) GB disk")
+                }
+                LabeledContent("Display") {
+                    Text(displaySummary)
+                }
+            } header: {
+                Label("Ready to Create", systemImage: "checkmark.circle")
             }
         }
         .formStyle(.grouped)
-        .onChange(of: useEnhancedFramebuffer) { clampDepth() }
-        .onChange(of: resolution) { clampDepth() }
-        .onChange(of: family) { _, newFamily in applyFamilyDefaults(newFamily) }
-    }
-
-    // Reset the fields that have per-family defaults, but keep a name the user
-    // typed themselves.
-    private func applyFamilyDefaults(_ newFamily: MachineFamily) {
-        let defaultNames = MachineFamily.allCases.map { $0.defaultName }
-        if defaultNames.contains(name) {
-            name = newFamily.defaultName
-        }
-        ramMB = newFamily.defaultRAMMB
-        diskSizeGB = newFamily.defaultDiskSizeGB
-        if !newFamily.supportsSharedFolder {
-            sharedFolderURL = nil
-        }
-        if !newFamily.supportsCustomResolution {
-            customResolution = false
-        }
     }
 
     private var footer: some View {
-        HStack {
-            if let errorMessage = errorMessage {
+        HStack(spacing: 10) {
+            if let errorMessage {
                 Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.red)
                     .lineLimit(2)
             }
+
+            if step != .machine {
+                Button("Back") {
+                    moveStep(by: -1)
+                }
+                .disabled(working)
+            }
+
             Spacer()
+
             Button("Cancel") {
                 dismiss()
             }
             .keyboardShortcut(.cancelAction)
-            Button("Create") {
-                create()
+            .disabled(working)
+
+            if step == .media {
+                Button("Create Machine") {
+                    create()
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .disabled(!hasValidName || working)
+            } else {
+                Button("Continue") {
+                    moveStep(by: 1)
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .disabled(!hasValidName || working)
             }
-            .keyboardShortcut(.defaultAction)
-            .buttonStyle(.borderedProminent)
-            .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty || working)
         }
-        .padding(20)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
     }
 
     private var workingOverlay: some View {
@@ -251,26 +374,64 @@ struct NewVMSheet: View {
             .padding(24)
             .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
         }
+        .contentShape(Rectangle())
+    }
+
+    private var hasValidName: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private var availableDepths: [ColorDepth] {
-        if useEnhancedFramebuffer {
-            return ColorDepth.allCases
-        }
-        var activeWidth = resolution.width
-        if customResolution {
-            activeWidth = customWidth
-        }
-        if activeWidth >= 1152 {
-            return [.greys256]
-        }
-        return ColorDepth.allCases
+        guard !useEnhancedFramebuffer else { return ColorDepth.allCases }
+        return resolution.width >= 1152 ? [.greys256] : ColorDepth.allCases
     }
 
     private var bundleFileName: String {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        let base = trimmed.isEmpty ? "Machine" : trimmed
-        return "\(base).\(VMConfig.packageExtension)"
+        return "\(trimmed.isEmpty ? "Machine" : trimmed).\(VMConfig.packageExtension)"
+    }
+
+    private var displayFooter: String {
+        if family == .powerMacG4 {
+            return "The Mac starts at this size in millions of colors. Drag its window after startup to resize the guest display."
+        }
+        return "This is the startup size and deepest available color mode. Lower modes remain available in the Monitors control panel."
+    }
+
+    private var displaySummary: String {
+        let size = customResolution ? "\(customWidth) \u{00D7} \(customHeight)" : resolution.label
+        if family == .powerMacG4 {
+            return "\(size) \u{2022} Millions"
+        }
+        return "\(size) \u{2022} \(depth.label)"
+    }
+
+    private func moveStep(by offset: Int) {
+        guard let next = SetupStep(rawValue: step.rawValue + offset) else { return }
+        errorMessage = nil
+        step = next
+    }
+
+    // Reset fields with model-specific defaults while preserving a custom name.
+    private func applyFamilyDefaults(_ newFamily: MachineFamily) {
+        let defaultNames = MachineFamily.allCases.map(\.defaultName)
+        if defaultNames.contains(name) {
+            name = newFamily.defaultName
+        }
+        ramMB = newFamily.defaultRAMMB
+        diskSizeGB = newFamily.defaultDiskSizeGB
+        useEnhancedFramebuffer = newFamily.supportsEnhancedFramebuffer
+        customResolution = false
+        resolution = .recommended
+        depth = .thousands
+        sound = newFamily.supportsSound
+    }
+
+    private func bounded(_ source: Binding<Int>, minimum: Int, maximum: Int) -> Binding<Int> {
+        Binding(
+            get: { source.wrappedValue },
+            set: { source.wrappedValue = min(max($0, minimum), maximum) }
+        )
     }
 
     private func chooseSaveFolder() {
@@ -294,6 +455,7 @@ struct NewVMSheet: View {
         panel.canChooseFiles = false
         panel.canCreateDirectories = true
         panel.message = "Choose a folder on this Mac to share with your classic Mac"
+        panel.prompt = "Share"
         if panel.runModal() == .OK {
             sharedFolderURL = panel.url
         }
@@ -301,21 +463,13 @@ struct NewVMSheet: View {
 
     private func matchMainDisplay() {
         guard let screen = NSScreen.main else { return }
-        var width = Int(screen.frame.width)
-        var height = Int(screen.frame.height)
-        if width > VMConfig.maxWidth {
-            width = VMConfig.maxWidth
-        }
-        if height > VMConfig.maxHeight {
-            height = VMConfig.maxHeight
-        }
-        customWidth = width
-        customHeight = height
+        customWidth = VMConfig.clampedWidth(Int(screen.frame.width))
+        customHeight = VMConfig.clampedHeight(Int(screen.frame.height))
     }
 
     private func clampDepth() {
-        if !availableDepths.contains(depth) {
-            depth = availableDepths.first!
+        if !availableDepths.contains(depth), let fallback = availableDepths.first {
+            depth = fallback
         }
     }
 
@@ -323,43 +477,31 @@ struct NewVMSheet: View {
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
-        var types: [UTType] = [.diskImage]
-        if let iso = UTType(filenameExtension: "iso") { types.append(iso) }
-        if let toast = UTType(filenameExtension: "toast") { types.append(toast) }
-        if let cdr = UTType(filenameExtension: "cdr") { types.append(cdr) }
-        panel.allowedContentTypes = types
+        panel.allowedContentTypes = isoContentTypes
+        panel.message = "Choose a CD image (.iso, .toast, or .cdr)"
+        panel.prompt = "Choose"
         if panel.runModal() == .OK {
             isoURL = panel.url
         }
     }
 
+    private var isoContentTypes: [UTType] {
+        var types: [UTType] = [.diskImage]
+        for ext in ["iso", "toast", "cdr"] {
+            if let type = UTType(filenameExtension: ext) {
+                types.append(type)
+            }
+        }
+        return types
+    }
+
     private func create() {
         errorMessage = nil
 
-        var width = resolution.width
-        var height = resolution.height
-        if customResolution && family.supportsCustomResolution {
-            width = customWidth
-            if width > VMConfig.maxWidth {
-                width = VMConfig.maxWidth
-            }
-            height = customHeight
-            if height > VMConfig.maxHeight {
-                height = VMConfig.maxHeight
-            }
-        }
-
-        let trimmedName = name.trimmingCharacters(in: .whitespaces)
-        let bundleURL = VMStore.shared.uniqueBundleURL(in: saveFolder, name: trimmedName)
-
-        var effectiveSound = sound
-        if !family.supportsSound {
-            effectiveSound = false
-        }
-        var effectiveSharedFolder = sharedFolderURL?.path
-        if !family.supportsSharedFolder {
-            effectiveSharedFolder = nil
-        }
+        let width = customResolution ? VMConfig.clampedWidth(customWidth) : resolution.width
+        let height = customResolution ? VMConfig.clampedHeight(customHeight) : resolution.height
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let bundleURL = store.uniqueBundleURL(in: saveFolder, name: trimmedName)
 
         let config = VMConfig(
             name: trimmedName,
@@ -369,56 +511,87 @@ struct NewVMSheet: View {
             width: width,
             height: height,
             depth: depth.rawValue,
-            useEnhancedFramebuffer: useEnhancedFramebuffer && family.supportsEnhancedFramebuffer,
-            customResolution: customResolution && family.supportsCustomResolution,
+            useEnhancedFramebuffer: useEnhancedFramebuffer,
+            customResolution: customResolution,
             cdImagePath: isoURL?.path,
             bootFromCD: isoURL != nil,
             networking: true,
-            sound: effectiveSound,
-            sharedFolderPath: effectiveSharedFolder,
+            sound: sound,
+            sharedFolderPath: sharedFolderURL?.path,
             bundleURL: bundleURL
         )
 
-        let needsCopy = isoURL != nil && copyISOIntoLibrary
-        if !needsCopy {
-            onCreate(config)
-            dismiss()
+        guard let source = isoURL, copyISOIntoLibrary else {
+            if onCreate(config) {
+                dismiss()
+            }
             return
         }
 
         working = true
-        workingMessage = "Copying install disc..."
-        let source = isoURL!
+        workingMessage = "Copying \(source.lastPathComponent)\u{2026}"
+        let destination = VMStore.uniqueFileURL(
+            in: AppPaths.mediaDir,
+            suggestedName: source.lastPathComponent
+        )
         Task {
-            let destination = AppPaths.mediaDir.appendingPathComponent(source.lastPathComponent)
             let copyError = await copyFile(from: source, to: destination)
             await MainActor.run {
                 working = false
-                if let copyError = copyError {
+                if let copyError {
                     errorMessage = copyError
                     return
                 }
                 var finalConfig = config
                 finalConfig.cdImagePath = destination.path
-                onCreate(finalConfig)
-                dismiss()
+                if onCreate(finalConfig) {
+                    dismiss()
+                }
             }
         }
     }
 
     private func copyFile(from source: URL, to destination: URL) async -> String? {
         await Task.detached(priority: .userInitiated) {
-            let fm = FileManager.default
-            if fm.fileExists(atPath: destination.path) {
-                return nil
-            }
             do {
-                try fm.copyItem(at: source, to: destination)
+                try FileManager.default.copyItem(at: source, to: destination)
                 return nil
             } catch {
-                return error.localizedDescription
+                return "The install disc could not be copied. \(error.localizedDescription)"
             }
         }.value
+    }
+}
+
+private enum SetupStep: Int, CaseIterable, Identifiable {
+    case machine
+    case hardware
+    case media
+
+    var id: Int { rawValue }
+
+    var title: String {
+        switch self {
+        case .machine: return "Machine"
+        case .hardware: return "Hardware"
+        case .media: return "Install & Share"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .machine: return "Choose a Mac model and where to keep it."
+        case .hardware: return "Tune memory, storage, and display settings."
+        case .media: return "Add installation media and review your choices."
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .machine: return "macpro.gen1"
+        case .hardware: return "memorychip"
+        case .media: return "opticaldiscdrive"
+        }
     }
 }
 
@@ -431,26 +604,36 @@ private struct MachineTile: View {
 
     var body: some View {
         Button(action: action) {
-            VStack(spacing: 8) {
-                MachineBadgeView(family: family, size: 56)
-                Text(family.label)
-                    .font(.headline)
-                Text(family.osSupportLabel)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+            HStack(spacing: 14) {
+                MachineBadgeView(family: family, size: 52)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(family.label)
+                        .font(.headline)
+                    Text(family.cpuLabel)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(family.osSupportLabel)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+                if selected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.tint)
+                        .accessibilityHidden(true)
+                }
             }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 14)
-            .padding(.horizontal, 8)
+            .frame(maxWidth: .infinity, minHeight: 74)
+            .padding(.horizontal, 14)
             .background(
-                RoundedRectangle(cornerRadius: 12)
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .fill(selected ? Color.accentColor.opacity(0.1) : Color(nsColor: .quaternarySystemFill))
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 12)
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .strokeBorder(selected ? Color.accentColor : Color.clear, lineWidth: 2)
             )
-            .contentShape(RoundedRectangle(cornerRadius: 12))
+            .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         }
         .buttonStyle(.plain)
         .accessibilityAddTraits(selected ? .isSelected : [])

--- a/app/Sources/ClassicMac/QEMURunner.swift
+++ b/app/Sources/ClassicMac/QEMURunner.swift
@@ -37,6 +37,7 @@ final class QEMUManager: ObservableObject {
     // kept after shutdown so the library shows what was last on screen.
     @Published private(set) var previews: [UUID: NSImage] = [:]
     @Published var lastError: AppError?
+    @Published private(set) var pendingStopID: UUID?
 
     private var processes: [UUID: Process] = [:]
     private var qmpMonitors: [UUID: QMPEventMonitor] = [:]
@@ -122,6 +123,9 @@ final class QEMUManager: ObservableObject {
                 let monitor = self.qmpMonitors.removeValue(forKey: config.id)
                 self.runningIDs.remove(config.id)
                 self.pausedIDs.remove(config.id)
+                if self.pendingStopID == config.id {
+                    self.pendingStopID = nil
+                }
                 self.processes.removeValue(forKey: config.id)
                 self.stopPreviewUpdates(for: config.id)
                 self.persistPreview(config)
@@ -245,7 +249,22 @@ final class QEMUManager: ObservableObject {
         try? png.write(to: bundle.appendingPathComponent("preview.png"))
     }
 
-    func stop(_ id: UUID) {
+    func requestStop(_ id: UUID) {
+        guard runningIDs.contains(id) else { return }
+        pendingStopID = id
+    }
+
+    func cancelStop() {
+        pendingStopID = nil
+    }
+
+    func confirmStop() {
+        guard let id = pendingStopID else { return }
+        pendingStopID = nil
+        stop(id)
+    }
+
+    private func stop(_ id: UUID) {
         guard let process = processes[id] else { return }
         process.terminate()
     }

--- a/app/Sources/ClassicMac/VMConfig.swift
+++ b/app/Sources/ClassicMac/VMConfig.swift
@@ -201,6 +201,7 @@ struct VMConfig: Codable, Identifiable, Hashable {
         self.classicInputHelpers = classicInputHelpers
         self.sharedFolderPath = sharedFolderPath
         self.bundleURL = bundleURL
+        sanitize()
     }
 
     // Bounds accepted by the enhanced framebuffer.
@@ -208,6 +209,14 @@ struct VMConfig: Codable, Identifiable, Hashable {
     static let maxHeight = 2160
     static let minWidth = 512
     static let minHeight = 384
+
+    static func clampedWidth(_ value: Int) -> Int {
+        min(max(value, minWidth), maxWidth)
+    }
+
+    static func clampedHeight(_ value: Int) -> Int {
+        min(max(value, minHeight), maxHeight)
+    }
 
     // Tolerant decoding so VMs created by older builds keep loading.
     init(from decoder: Decoder) throws {
@@ -244,11 +253,36 @@ struct VMConfig: Codable, Identifiable, Hashable {
     // with 1 GB or more of RAM, so early PPC configs with bigger values are
     // pulled back to 896 MB.
     private mutating func sanitize() {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        name = trimmedName.isEmpty ? machineFamily.defaultName : trimmedName
+
         if machineFamily == .powerMacG4 {
             if ramMB > 896 {
                 ramMB = 896
             }
             useEnhancedFramebuffer = false
+        }
+        width = Self.clampedWidth(width)
+        height = Self.clampedHeight(height)
+
+        // A standard-framebuffer Quadra only exposes the known preset modes.
+        // Keep the stored size and the picker in agreement when loading an
+        // older or hand-edited configuration.
+        if machineFamily == .quadra800 && !useEnhancedFramebuffer {
+            customResolution = false
+        }
+        if !customResolution {
+            let preset = ResolutionPreset.closest(toWidth: width, height: height)
+            width = preset.width
+            height = preset.height
+        }
+
+        let validDepths = Set(ColorDepth.allCases.map(\.rawValue))
+        if !validDepths.contains(depth) {
+            depth = ColorDepth.thousands.rawValue
+        }
+        if machineFamily == .quadra800 && !useEnhancedFramebuffer && width >= 1152 {
+            depth = ColorDepth.greys256.rawValue
         }
         if !machineFamily.supportsSharedFolder {
             sharedFolderPath = nil
@@ -339,6 +373,20 @@ struct ResolutionPreset: Identifiable, Hashable {
         ResolutionPreset(width: 1280, height: 1024),
         ResolutionPreset(width: 1440, height: 900)
     ]
+
+    static let recommended = all[2]
+
+    static func matching(width: Int, height: Int) -> ResolutionPreset? {
+        all.first { $0.width == width && $0.height == height }
+    }
+
+    static func closest(toWidth width: Int, height: Int) -> ResolutionPreset {
+        all.min { lhs, rhs in
+            let lhsDistance = abs(lhs.width - width) + abs(lhs.height - height)
+            let rhsDistance = abs(rhs.width - width) + abs(rhs.height - height)
+            return lhsDistance < rhsDistance
+        } ?? recommended
+    }
 }
 
 // RAM presets now live on MachineFamily (see ramPresets there); the Quadra

--- a/app/Sources/ClassicMac/VMDetailView.swift
+++ b/app/Sources/ClassicMac/VMDetailView.swift
@@ -30,9 +30,9 @@ struct VMDetailView: View {
     }
 
     private var configBinding: Binding<VMConfig>? {
-        guard config != nil else { return nil }
+        guard let initialConfig = config else { return nil }
         return Binding(
-            get: { config! },
+            get: { config ?? initialConfig },
             set: { newValue in
                 config = newValue
                 store.save(newValue)
@@ -88,10 +88,19 @@ struct VMDetailView: View {
                 TextField("Name", text: vm.name)
                     .font(.title2.bold())
                     .textFieldStyle(.plain)
+                    .disabled(running)
                 Text(vm.wrappedValue.machineFamily.hardwareLabel)
                     .foregroundStyle(.secondary)
+                HStack(spacing: 14) {
+                    Label("\(vm.wrappedValue.ramMB) MB", systemImage: "memorychip")
+                    Label("\(vm.wrappedValue.diskSizeGB) GB", systemImage: "internaldrive")
+                    Label("\(vm.wrappedValue.width) \u{00D7} \(vm.wrappedValue.height)", systemImage: "display")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.top, 2)
                 if running {
-                    Text("Settings can be changed after the Mac shuts down.")
+                    Text("Settings are locked while this Mac is running.")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                 }
@@ -160,7 +169,7 @@ struct VMDetailView: View {
                         .resizable()
                         .scaledToFit()
                         .frame(maxWidth: .infinity)
-                        .frame(maxHeight: 300)
+                        .frame(maxHeight: 210)
                         .saturation(running ? 1 : 0.6)
                         .opacity(running ? 1 : 0.75)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
@@ -168,6 +177,16 @@ struct VMDetailView: View {
                             RoundedRectangle(cornerRadius: 8)
                                 .strokeBorder(.separator, lineWidth: 1)
                         )
+                        .overlay(alignment: .bottomTrailing) {
+                            if running {
+                                Label("Open Screen", systemImage: "arrow.up.forward.app")
+                                    .font(.caption.weight(.semibold))
+                                    .padding(.horizontal, 9)
+                                    .padding(.vertical, 6)
+                                    .background(.regularMaterial, in: Capsule())
+                                    .padding(10)
+                            }
+                        }
                 }
                 .buttonStyle(.plain)
                 .disabled(!running)
@@ -196,7 +215,7 @@ struct VMDetailView: View {
     @ViewBuilder
     private func powerMacDisplaySection(_ vm: Binding<VMConfig>) -> some View {
         Section {
-            Toggle("Custom resolution", isOn: vm.customResolution)
+            Toggle("Custom resolution", isOn: customResolutionSelection(vm))
                 .disabled(running)
 
             if vm.wrappedValue.customResolution {
@@ -219,7 +238,7 @@ struct VMDetailView: View {
     @ViewBuilder
     private func quadraDisplaySection(_ vm: Binding<VMConfig>) -> some View {
         Section {
-            Toggle(isOn: vm.useEnhancedFramebuffer) {
+            Toggle(isOn: enhancedFramebufferSelection(vm)) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Enhanced video card")
                     Text("Any resolution, with richer color at every size")
@@ -229,7 +248,7 @@ struct VMDetailView: View {
             }
             .disabled(running)
 
-            Toggle("Custom resolution", isOn: vm.customResolution)
+            Toggle("Custom resolution", isOn: customResolutionSelection(vm))
                 .disabled(running || !vm.wrappedValue.useEnhancedFramebuffer)
 
             if vm.wrappedValue.customResolution {
@@ -260,14 +279,22 @@ struct VMDetailView: View {
     private func customResolutionFields(_ vm: Binding<VMConfig>) -> some View {
         LabeledContent("Size") {
             HStack(spacing: 8) {
-                TextField("Width", value: maxClamped(vm.width, VMConfig.maxWidth), format: .number)
-                    .frame(width: 76)
-                    .multilineTextAlignment(.trailing)
+                TextField(
+                    "Width",
+                    value: bounded(vm.width, minimum: VMConfig.minWidth, maximum: VMConfig.maxWidth),
+                    format: .number
+                )
+                .frame(width: 76)
+                .multilineTextAlignment(.trailing)
                 Text("\u{00D7}")
                     .foregroundStyle(.secondary)
-                TextField("Height", value: maxClamped(vm.height, VMConfig.maxHeight), format: .number)
-                    .frame(width: 76)
-                    .multilineTextAlignment(.trailing)
+                TextField(
+                    "Height",
+                    value: bounded(vm.height, minimum: VMConfig.minHeight, maximum: VMConfig.maxHeight),
+                    format: .number
+                )
+                .frame(width: 76)
+                .multilineTextAlignment(.trailing)
                 Button("Match Display") {
                     matchMainDisplay(vm)
                 }
@@ -276,35 +303,18 @@ struct VMDetailView: View {
         .disabled(running)
     }
 
-    private func maxClamped(_ source: Binding<Int>, _ maxValue: Int) -> Binding<Int> {
+    private func bounded(_ source: Binding<Int>, minimum: Int, maximum: Int) -> Binding<Int> {
         Binding(
             get: { source.wrappedValue },
-            set: { newValue in
-                var value = newValue
-                if value > maxValue {
-                    value = maxValue
-                }
-                if value < 1 {
-                    value = 1
-                }
-                source.wrappedValue = value
-            }
+            set: { source.wrappedValue = min(max($0, minimum), maximum) }
         )
     }
 
     private func matchMainDisplay(_ vm: Binding<VMConfig>) {
         guard let screen = NSScreen.main else { return }
-        var width = Int(screen.frame.width)
-        var height = Int(screen.frame.height)
-        if width > VMConfig.maxWidth {
-            width = VMConfig.maxWidth
-        }
-        if height > VMConfig.maxHeight {
-            height = VMConfig.maxHeight
-        }
         vm.wrappedValue.customResolution = true
-        vm.wrappedValue.width = width
-        vm.wrappedValue.height = height
+        vm.wrappedValue.width = VMConfig.clampedWidth(Int(screen.frame.width))
+        vm.wrappedValue.height = VMConfig.clampedHeight(Int(screen.frame.height))
     }
 
     // MARK: Hardware
@@ -567,7 +577,7 @@ struct VMDetailView: View {
                 .help("Restart the Mac")
 
                 Button(role: .destructive) {
-                    manager.stop(vmID)
+                    manager.requestStop(vmID)
                 } label: {
                     Label("Shut Down", systemImage: "power")
                 }
@@ -617,14 +627,53 @@ struct VMDetailView: View {
 
     // MARK: Selection helpers
 
+    private func enhancedFramebufferSelection(_ vm: Binding<VMConfig>) -> Binding<Bool> {
+        Binding(
+            get: { vm.wrappedValue.useEnhancedFramebuffer },
+            set: { enabled in
+                vm.wrappedValue.useEnhancedFramebuffer = enabled
+                if !enabled {
+                    vm.wrappedValue.customResolution = false
+                    let preset = ResolutionPreset.closest(
+                        toWidth: vm.wrappedValue.width,
+                        height: vm.wrappedValue.height
+                    )
+                    vm.wrappedValue.width = preset.width
+                    vm.wrappedValue.height = preset.height
+                    clampDepth(vm)
+                }
+            }
+        )
+    }
+
+    private func customResolutionSelection(_ vm: Binding<VMConfig>) -> Binding<Bool> {
+        Binding(
+            get: { vm.wrappedValue.customResolution },
+            set: { isCustom in
+                vm.wrappedValue.customResolution = isCustom
+                if !isCustom {
+                    let preset = ResolutionPreset.closest(
+                        toWidth: vm.wrappedValue.width,
+                        height: vm.wrappedValue.height
+                    )
+                    vm.wrappedValue.width = preset.width
+                    vm.wrappedValue.height = preset.height
+                    clampDepth(vm)
+                }
+            }
+        )
+    }
+
     private func resolutionSelection(_ vm: Binding<VMConfig>) -> Binding<ResolutionPreset> {
         Binding(
             get: {
-                let match = ResolutionPreset.all.first { $0.width == vm.wrappedValue.width && $0.height == vm.wrappedValue.height }
-                if let match = match {
-                    return match
-                }
-                return ResolutionPreset.all[2]
+                ResolutionPreset.matching(
+                    width: vm.wrappedValue.width,
+                    height: vm.wrappedValue.height
+                ) ?? ResolutionPreset.closest(
+                    toWidth: vm.wrappedValue.width,
+                    height: vm.wrappedValue.height
+                )
             },
             set: { preset in
                 vm.wrappedValue.width = preset.width

--- a/app/Sources/ClassicMac/VMStore.swift
+++ b/app/Sources/ClassicMac/VMStore.swift
@@ -42,6 +42,7 @@ final class VMStore: ObservableObject {
     func reload() {
         migrateLegacyVMsIfNeeded()
 
+        let previousSelection = selectedID
         var loaded: [VMConfig] = []
         var validPaths: [String] = []
         for url in indexedBundleURLs() {
@@ -51,6 +52,11 @@ final class VMStore: ObservableObject {
         }
         loaded.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         vms = loaded
+        if let previousSelection, loaded.contains(where: { $0.id == previousSelection }) {
+            selectedID = previousSelection
+        } else {
+            selectedID = loaded.first?.id
+        }
         // Prune entries whose packages have gone missing.
         writeIndex(validPaths)
     }
@@ -198,8 +204,12 @@ final class VMStore: ObservableObject {
 
     // Forgets a VM but leaves its package on disk.
     func removeFromLibrary(_ config: VMConfig) {
+        let removedIndex = vms.firstIndex { $0.id == config.id }
         vms.removeAll { $0.id == config.id }
-        if selectedID == config.id { selectedID = nil }
+        if selectedID == config.id {
+            let nextIndex = min(removedIndex ?? 0, max(vms.count - 1, 0))
+            selectedID = vms.isEmpty ? nil : vms[nextIndex].id
+        }
         if let bundle = config.bundleURL {
             removeFromIndex(bundle)
         }
@@ -312,6 +322,35 @@ final class VMStore: ObservableObject {
         var counter = 2
         while fm.fileExists(atPath: candidate.path) {
             candidate = directory.appendingPathComponent("\(base) \(counter).\(VMConfig.packageExtension)")
+            counter += 1
+        }
+        return candidate
+    }
+
+    // A non-colliding URL for copied installation media. Keeping this logic
+    // beside package naming prevents a same-named disc from silently reusing
+    // an unrelated older image in the shared media directory.
+    nonisolated static func uniqueFileURL(in directory: URL, suggestedName: String) -> URL {
+        let source = URL(fileURLWithPath: suggestedName)
+        let ext = source.pathExtension
+        let rawBase = source.deletingPathExtension().lastPathComponent
+        var base = rawBase.trimmingCharacters(in: .whitespacesAndNewlines)
+        base = base.replacingOccurrences(of: "/", with: "-")
+        base = base.replacingOccurrences(of: ":", with: "-")
+        if base.isEmpty {
+            base = "Disc"
+        }
+        let fm = FileManager.default
+
+        func fileName(counter: Int?) -> String {
+            let suffix = counter.map { " \($0)" } ?? ""
+            return ext.isEmpty ? "\(base)\(suffix)" : "\(base)\(suffix).\(ext)"
+        }
+
+        var candidate = directory.appendingPathComponent(fileName(counter: nil))
+        var counter = 2
+        while fm.fileExists(atPath: candidate.path) {
+            candidate = directory.appendingPathComponent(fileName(counter: counter))
             counter += 1
         }
         return candidate

--- a/app/Tests/ClassicMacTests/VMConfigTests.swift
+++ b/app/Tests/ClassicMacTests/VMConfigTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import ClassicMac
+
+final class VMConfigTests: XCTestCase {
+    func testCustomResolutionIsClampedAndNameIsTrimmed() {
+        let config = VMConfig(
+            name: "  Studio Mac  ",
+            machineFamily: .powerMacG4,
+            ramMB: 1_024,
+            width: 5_000,
+            height: 100,
+            customResolution: true
+        )
+
+        XCTAssertEqual(config.name, "Studio Mac")
+        XCTAssertEqual(config.ramMB, 896)
+        XCTAssertEqual(config.width, VMConfig.maxWidth)
+        XCTAssertEqual(config.height, VMConfig.minHeight)
+        XCTAssertFalse(config.useEnhancedFramebuffer)
+    }
+
+    func testStandardQuadraNormalizesToSupportedPresetAndDepth() {
+        let config = VMConfig(
+            name: "Quadra",
+            machineFamily: .quadra800,
+            width: 1_300,
+            height: 1_000,
+            depth: ColorDepth.millions.rawValue,
+            useEnhancedFramebuffer: false,
+            customResolution: true
+        )
+
+        XCTAssertFalse(config.customResolution)
+        XCTAssertEqual(config.width, 1_280)
+        XCTAssertEqual(config.height, 1_024)
+        XCTAssertEqual(config.depth, ColorDepth.greys256.rawValue)
+    }
+
+    func testBlankNameFallsBackToModelDefault() {
+        let config = VMConfig(name: "  \n", machineFamily: .powerMacG4)
+
+        XCTAssertEqual(config.name, MachineFamily.powerMacG4.defaultName)
+    }
+
+    func testCopiedMediaNamesNeverReuseAnExistingFile() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let first = directory.appendingPathComponent("Install.iso")
+        try Data().write(to: first)
+
+        let candidate = VMStore.uniqueFileURL(
+            in: directory,
+            suggestedName: "Install.iso"
+        )
+
+        XCTAssertEqual(candidate.lastPathComponent, "Install 2.iso")
+    }
+}

--- a/scripts/build-ppcvid-ndrv.sh
+++ b/scripts/build-ppcvid-ndrv.sh
@@ -143,6 +143,8 @@ else
     export BUILD_PPC=true
     export BUILD_CARBON=false
     export INTERFACES_KIND=universal
+    # Resolved from the Retro68 checkout created earlier in this script.
+    # shellcheck source=/dev/null
     source "$RETRO68_SRC/interfaces-and-libraries.sh"
     locateAndCheckInterfacesAndLibraries
     setUpInterfacesAndLibraries

--- a/scripts/bundle-qemu.sh
+++ b/scripts/bundle-qemu.sh
@@ -38,7 +38,7 @@ HELPERS_DIR="$CONTENTS/Helpers"
 QUADRA_APP="$HELPERS_DIR/Quadra 800.app"
 PPC_APP="$HELPERS_DIR/Power Mac G4.app"
 
-APP_VERSION="${APP_VERSION:-1.5.0}"
+APP_VERSION="${APP_VERSION:-1.6.0}"
 BUNDLE_ID="com.classicmac.emulator"
 
 log() { printf '\n==> %s\n' "$*"; }
@@ -122,8 +122,11 @@ for spec in \
   "512 icon_256x256@2x" \
   "512 icon_512x512" \
   "1024 icon_512x512@2x"; do
-  set -- $spec
-  sips -z "$1" "$1" "$ICON_PNG" --out "$ICONSET_DIR/$2.png" >/dev/null || die "Failed to scale AppIcon.png to $1x$1"
+  read -r icon_size icon_name <<< "$spec"
+  if ! sips -z "$icon_size" "$icon_size" "$ICON_PNG" \
+    --out "$ICONSET_DIR/$icon_name.png" >/dev/null; then
+    die "Failed to scale AppIcon.png to ${icon_size}x${icon_size}"
+  fi
 done
 iconutil --convert icns -o "$RES_DIR/AppIcon.icns" "$ICONSET_DIR" || die "iconutil failed to build AppIcon.icns"
 rm -rf "$(dirname "$ICONSET_DIR")"


### PR DESCRIPTION
## Summary

- replace the long new-machine form with a guided three-step setup and final review
- make the machine library select useful content by default and improve the detail overview
- add force-shutdown confirmation and consistent configuration normalization
- prevent same-named copied installation media from reusing an older file
- add regression coverage and clean up release-script shell warnings
- bump the bundled app version and changelog to 1.6.0

## User impact

Machine creation is easier to follow, existing libraries open directly to a machine, important hardware information stays visible, and potentially destructive or invalid configuration paths are safer.

## Validation

- `swift test --package-path app` — 20 tests pass
- production app bundle built successfully
- Developer ID deep-signature verification passed
- app notarization accepted and stapled
- DMG notarization accepted and stapled
- Gatekeeper accepted both app and DMG as Notarized Developer ID
- `shellcheck scripts/*.sh tools/os9-install-harness/*.sh`
- `git diff --check`
