### PR TITLE
Improve Mac OS 9 boot performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- ClassicMac's Shut Down command now uses the emulated ADB Power key and
+  confirms Mac OS's native shutdown dialog. HFS/HFS+ volumes are cleanly
+  unmounted, avoiding the recovery work that added roughly 5–6 seconds to the
+  next tested Mac OS 9 startup. A 15-second forced-off fallback remains for an
+  unresponsive guest.
+
+### Performance
+
+- PowerPC BAT updates now use QEMU's range-aware TLB invalidation instead of
+  flushing hundreds of pages one at a time. On a clean controlled Mac OS 9.2
+  image this reduced mean time to Finder from 28.82 to 26.78 seconds (-7.1%).
+- Added a disposable-disk boot benchmark and documented an optional
+  emulator-specific Extension Manager profile. The full profile saved another
+  0.67 seconds in the tested universal Mac OS 9.2 install, so it is not applied
+  automatically.
+
 ## 2.0.1 — 2026-08-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ ClassicMac exists because of years of brilliant work by other engineers. The pat
   game is launched. A classic puzzle-piece M appears in the startup extension
   row when GXMetal's companion loads.
 - **Native machine control.** Pause / Resume, Restart, and Shut Down from the app, live screen previews in the library, and a "Match Display" button that sizes the Mac to your screen.
+- **Safe, faster shutdown cycles.** The app's Shut Down command presses the
+  virtual Mac's Power key and confirms Mac OS's own dialog, allowing HFS/HFS+
+  to unmount cleanly so the next boot does not pay the recovery penalty.
 - **Machine window shortcuts that always work.** Control-Option-T hides or restores the title bar for a clean borderless look, Control-Option-F toggles Full Screen, and Control-Option-R matches the Mac screen to the window again. All three keep working even while the emulator has grabbed the keyboard, and they also live in the **View** menu and the machine's Dock icon menu.
 - **Signed, notarized, stapled DMG** for distribution — recipients get a clean Gatekeeper experience even offline.
 

--- a/app/Sources/ClassicMac/ContentView.swift
+++ b/app/Sources/ClassicMac/ContentView.swift
@@ -41,14 +41,14 @@ struct ContentView: View {
             isPresented: stopConfirmationBinding,
             titleVisibility: .visible
         ) {
-            Button("Shut Down Now", role: .destructive) {
+            Button("Shut Down", role: .destructive) {
                 manager.confirmStop()
             }
             Button("Cancel", role: .cancel) {
                 manager.cancelStop()
             }
         } message: {
-            Text("This turns the machine off immediately and may lose unsaved work. When possible, shut down from inside Mac OS instead.")
+            Text("ClassicMac will ask Mac OS to shut down safely so its disk stays healthy and the next startup is faster. If Mac OS does not respond, the machine will turn off after 15 seconds and unsaved work may be lost.")
         }
     }
 

--- a/app/Sources/ClassicMac/QEMURunner.swift
+++ b/app/Sources/ClassicMac/QEMURunner.swift
@@ -42,6 +42,7 @@ final class QEMUManager: ObservableObject {
     private var processes: [UUID: Process] = [:]
     private var qmpMonitors: [UUID: QMPEventMonitor] = [:]
     private var previewTimers: [UUID: Timer] = [:]
+    private var forcedStopWorkItems: [UUID: DispatchWorkItem] = [:]
 
     func isRunning(_ id: UUID) -> Bool {
         runningIDs.contains(id)
@@ -133,6 +134,7 @@ final class QEMUManager: ObservableObject {
                     self.pendingStopID = nil
                 }
                 self.processes.removeValue(forKey: config.id)
+                self.forcedStopWorkItems.removeValue(forKey: config.id)?.cancel()
                 self.stopPreviewUpdates(for: config.id)
                 self.persistPreview(config)
                 if proc.terminationStatus != 0 && proc.terminationReason == .exit {
@@ -272,7 +274,54 @@ final class QEMUManager: ObservableObject {
 
     private func stop(_ id: UUID) {
         guard let process = processes[id] else { return }
-        process.terminate()
+        let socketPath = QEMUManager.monitorSocketURL(for: id).path
+        let wasPaused = pausedIDs.remove(id) != nil
+
+        // An immediate SIGTERM leaves a mounted HFS/HFS+ volume marked dirty.
+        // Mac OS checks that volume on its next startup, adding several seconds
+        // and risking data loss. The ADB power key opens the guest's native
+        // one-button Shut Down dialog; Return confirms it and lets Mac OS flush
+        // the disk before CUDA/PMU asks QEMU to exit.
+        DispatchQueue.global(qos: .userInitiated).async { [weak self, weak process] in
+            if wasPaused {
+                _ = HMPClient.send("cont", socketPath: socketPath)
+                usleep(100_000)
+            }
+            guard HMPClient.send("sendkey power", socketPath: socketPath) else {
+                Task { @MainActor in
+                    process?.terminate()
+                    self?.forcedStopWorkItems.removeValue(forKey: id)?.cancel()
+                }
+                return
+            }
+            usleep(750_000)
+            guard process?.isRunning == true,
+                  HMPClient.send("sendkey ret", socketPath: socketPath) else {
+                Task { @MainActor in
+                    if process?.isRunning == true {
+                        process?.terminate()
+                    }
+                    self?.forcedStopWorkItems.removeValue(forKey: id)?.cancel()
+                }
+                return
+            }
+        }
+
+        // A crashed guest or an application blocking shutdown must not leave
+        // the emulator stuck forever. This preserves the old forced-off
+        // behavior as a bounded fallback, after giving Mac OS ample time to
+        // finish an ordinary shutdown.
+        let fallback = DispatchWorkItem { [weak self, weak process] in
+            if process?.isRunning == true {
+                process?.terminate()
+            }
+            Task { @MainActor in
+                self?.forcedStopWorkItems.removeValue(forKey: id)
+            }
+        }
+        forcedStopWorkItems[id]?.cancel()
+        forcedStopWorkItems[id] = fallback
+        DispatchQueue.main.asyncAfter(deadline: .now() + 15, execute: fallback)
     }
 
     func pause(_ id: UUID) {

--- a/app/Sources/ClassicMac/VMDetailView.swift
+++ b/app/Sources/ClassicMac/VMDetailView.swift
@@ -604,7 +604,7 @@ struct VMDetailView: View {
                 } label: {
                     Label("Shut Down", systemImage: "power")
                 }
-                .help("Turn the Mac off immediately")
+                .help("Ask Mac OS to shut down safely")
             }
         } else {
             ToolbarItem {

--- a/docs/os9-boot-performance.md
+++ b/docs/os9-boot-performance.md
@@ -1,0 +1,86 @@
+# Mac OS 9 boot performance
+
+ClassicMac shortens a measured Mac OS 9.2 startup at two layers: QEMU now
+invalidates PowerPC BAT mappings as ranges, and the app asks Mac OS to shut
+down natively so the boot volume remains clean. An optional Extension Manager
+trim is possible, but its measured benefit is much smaller.
+
+## Controlled result
+
+The test used the same Mac OS 9.2 disk, PowerPC 7400, 512 MiB of RAM,
+1024 x 768 Thousands-color display, GXMetal transport, ClassicMac Tools,
+Virtio tablet, shared folder, and Sungem network device. Every run cloned the
+source image before QEMU opened it. Finder readiness was detected from QEMU's
+normal framebuffer through HMP `screendump`; the test never booted the source
+image itself.
+
+| Configuration | Finder runs (seconds) | Mean | Change |
+| --- | --- | ---: | ---: |
+| Installed ClassicMac 2.0.1, clean HFS+ volume | 29.15, 28.66, 28.64 | 28.82 | baseline |
+| BAT range invalidation, clean volume | 26.61, 26.63, 27.09 | 26.78 | -2.04 s (-7.1%) |
+| BAT range invalidation plus hardware-extension trim | 26.11, 26.13, 26.09 | 26.11 | -2.71 s (-9.4%) |
+
+These comparison runs used QEMU's `cache=none` mode to prevent a preceding
+host mount from warming macOS's file cache. Normal cached runs produced the
+same ordering. The reproducible harness is `scripts/benchmark-os9-boot.py`.
+
+## QEMU PowerPC BAT invalidation
+
+During Mac OS startup, the PowerPC guest changes block-address-translation
+(BAT) registers frequently. QEMU 11.0.2 invalidated every 4 KiB page in the
+old and new BAT regions independently. A 20-second Apple Silicon sample found
+3,037 samples inside page-at-a-time TLB invalidation, making it the dominant
+named host-side boot hotspot.
+
+`powermac/tcg-ppc-bat-range-flush.patch` sends the same contiguous virtual
+address region through QEMU's existing `tlb_flush_range_by_mmuidx()` API. The
+API takes the TLB lock once, chooses a bounded scan or full flush based on the
+range and TLB size, and clears the jump cache efficiently. The optimized
+profile recorded 94 samples in range invalidation instead of 3,037 page-flush
+samples. Guest mappings and invalidation coverage are unchanged.
+
+## Clean app-controlled shutdown
+
+The former ClassicMac **Shut Down** action sent SIGTERM to QEMU. That behaved
+like pulling the plug: HFS+ left its `kHFSVolumeUnmountedBit` clear, so Mac OS
+performed extra recovery work during the next startup. On the test image this
+added roughly 5–6 seconds and about 2,300 IDE DMA completions.
+
+ClassicMac now sends QEMU's emulated ADB Power key, waits for Mac OS's native
+Shut Down dialog, and confirms its default button. The guest flushes the disk
+and exits through CUDA/PMU normally. The retained 15-second forced-off fallback
+only runs if the guest is crashed or refuses to shut down. A guest-produced
+test changed the HFS+ attributes from `0x80000000` to `0x80000100`; its next
+boot reached Finder in 26.63 seconds without any host mount or repair.
+
+Shutting down from the Special menu inside Mac OS remains equally safe.
+
+## Optional Extension Manager profile
+
+The universal Mac OS 9.2 install contains drivers for hardware ClassicMac does
+not expose. Disabling the following complete set reduced a clean optimized
+boot by another 0.67 seconds (about 2.5%) and roughly 250 IDE DMA completions
+in this image:
+
+- NVIDIA: `NVIDIA 2D Acceleration`, `NVIDIA DVD Accelerator`, `NVIDIA Driver`,
+  `NVIDIA Engine`, `NVIDIA OpenGL`, and `NVIDIA Video Accelerator`.
+- DVD and external video: `DVD AutoLauncher`, `DVD Navigation Manager ATI`,
+  `DVD Navigation Manager NV`, `DVD Region Manager`, `DVD Video Interface`,
+  `DVDRuntimeLib`, `Theater Mode`, `QuickTime FireWire DV Enabler`, and
+  `QuickTime FireWire DV Support`.
+- Wireless and telecom: `AirPort AP`, `AirPort AP Support`, `AirPort Driver`,
+  `Internal V.90 Modem`, `PowerMac G3 Modem`, `iMac Modem Extension`,
+  `IrDA Tool`, and `IrDALib`.
+- Unavailable removable buses: `Iomega Driver`, `USB Device Extension`,
+  `USB Mass Storage Support`, `USB Software Locator`, `USB Support`, and
+  `USBAppleMonitorModule`.
+
+This remains optional because the gain is modest and a user's System Folder
+may be portable to real hardware or another emulator. Use Extensions Manager
+to create a duplicate set before disabling anything, which makes rollback
+straightforward.
+
+Keep the networking extensions (`Apple Enet`, Open Transport, DNS), core sound
+and QuickTime components, CarbonLib, InputSprocket/DrawSprocket, QuickDraw 3D,
+RAVE, and every GXMetal component. They support devices or games ClassicMac
+actually runs.

--- a/powermac/tcg-ppc-bat-range-flush.patch
+++ b/powermac/tcg-ppc-bat-range-flush.patch
@@ -1,0 +1,32 @@
+diff --git a/target/ppc/mmu_helper.c b/target/ppc/mmu_helper.c
+index ac607054027..551923ccbc3 100644
+--- a/target/ppc/mmu_helper.c
++++ b/target/ppc/mmu_helper.c
+@@ -150,23 +150,16 @@ static inline void do_invalidate_BAT(CPUPPCState *env, target_ulong BATu,
+                                      target_ulong mask)
+ {
+     CPUState *cs = env_cpu(env);
+-    target_ulong base, end, page;
++    target_ulong base, end;
+ 
+     base = BATu & ~0x0001FFFF;
+     end = base + mask + 0x00020000;
+-    if (((end - base) >> TARGET_PAGE_BITS) > 1024) {
+-        /* Flushing 1024 4K pages is slower than a complete flush */
+-        qemu_log_mask(CPU_LOG_MMU, "Flush all BATs\n");
+-        tlb_flush(cs);
+-        qemu_log_mask(CPU_LOG_MMU, "Flush done\n");
+-        return;
+-    }
+     qemu_log_mask(CPU_LOG_MMU, "Flush BAT from " TARGET_FMT_lx
+                   " to " TARGET_FMT_lx " (" TARGET_FMT_lx ")\n",
+                   base, end, mask);
+-    for (page = base; page != end; page += TARGET_PAGE_SIZE) {
+-        tlb_flush_page(cs, page);
+-    }
++    tlb_flush_range_by_mmuidx(cs, base, end - base,
++                              (1u << NB_MMU_MODES) - 1,
++                              TARGET_LONG_BITS);
+     qemu_log_mask(CPU_LOG_MMU, "Flush done\n");
+ }
+ #endif

--- a/scripts/benchmark-os9-boot.py
+++ b/scripts/benchmark-os9-boot.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Measure Mac OS 9 boot time using a disposable disk-image clone.
+
+The benchmark launches the repository's Power Mac QEMU with the same core
+devices as ClassicMac, polls QEMU's framebuffer through the monitor socket,
+and stops when the Finder menu bar is fully visible.  The source disk is never
+attached or written.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+
+
+FINDER_DARK_PIXELS = 800
+FINDER_BRIGHT_PIXELS = 10_000
+
+
+def receive_until_prompt(connection: socket.socket) -> bytes:
+    response = bytearray()
+    while not response.endswith(b"(qemu) "):
+        chunk = connection.recv(4096)
+        if not chunk:
+            raise RuntimeError("QEMU monitor closed unexpectedly")
+        response.extend(chunk)
+    return bytes(response)
+
+
+def capture_frame(connection: socket.socket, path: Path) -> tuple[int, int, bytes]:
+    connection.sendall(f"screendump {path}\n".encode("utf-8"))
+    response = receive_until_prompt(connection)
+    if b"Error" in response:
+        raise RuntimeError(response.decode("utf-8", "replace"))
+
+    data = path.read_bytes()
+    first, dimensions, maximum, rgb = data.split(b"\n", 3)
+    if first != b"P6" or maximum != b"255":
+        raise RuntimeError(f"unexpected screendump format in {path}")
+    width, height = (int(value) for value in dimensions.split())
+    if len(rgb) != width * height * 3:
+        raise RuntimeError(f"truncated screendump in {path}")
+    return width, height, rgb
+
+
+def finder_is_ready(width: int, rgb: bytes) -> bool:
+    band_height = 20
+    band = memoryview(rgb)[: width * band_height * 3]
+    dark = 0
+    bright = 0
+    for offset in range(0, len(band), 3):
+        red, green, blue = band[offset : offset + 3]
+        if max(red, green, blue) < 50:
+            dark += 1
+        if min(red, green, blue) > 170:
+            bright += 1
+    return dark >= FINDER_DARK_PIXELS and bright >= FINDER_BRIGHT_PIXELS
+
+
+def welcome_is_visible(width: int, height: int, rgb: bytes) -> bool:
+    bright = 0
+    for y in range(height // 2 - 190, height // 2 + 80):
+        for x in range(width // 2 - 220, width // 2 + 220):
+            offset = (y * width + x) * 3
+            if min(rgb[offset : offset + 3]) > 220:
+                bright += 1
+    return bright > 20_000
+
+
+def desktop_is_visible(width: int, rgb: bytes) -> bool:
+    offset = (30 * width + 10) * 3
+    red, green, blue = rgb[offset : offset + 3]
+    return blue > red + 20 and blue > green + 20
+
+
+def clone_disk(source: Path, destination: Path) -> None:
+    result = subprocess.run(
+        ["cp", "-c", str(source), str(destination)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if result.returncode != 0:
+        shutil.copyfile(source, destination)
+
+
+def qemu_command(
+    root: Path,
+    qemu: Path,
+    disk: Path,
+    scratch: Path,
+    dma_delay_ns: int,
+    ram_mb: int,
+    disk_cache: str | None,
+    accel: str,
+    cpu: str,
+    shared_folder: Path | None,
+    icount: str | None,
+    extra_qemu_args: list[str],
+    minimal_devices: bool,
+) -> list[str]:
+    firmware = root / "vendor/qemu/pc-bios"
+    tools = root / "dist/ClassicMacTools.iso"
+    loader = root / "shared/ndrvloader"
+    command = [
+        str(qemu),
+        "-accel", accel,
+        "-M", "mac99,via=cuda,audiodev=snd0",
+        "-cpu", cpu,
+        "-m", str(ram_mb),
+        "-L", str(firmware),
+        "-display", "none",
+        "-vnc", f"unix:{scratch / 'vnc.sock'}",
+        "-vga", "std",
+        "-global", "VGA.host-resize=on",
+        "-global", "VGA.vgamem_mb=64",
+        "-global", "VGA.packed-lowbpp=on",
+        "-global", "VGA.untracked-vram=on",
+        "-global", "VGA.hardware-cursor=on",
+        "-global", "VGA.gxmetal=on",
+        "-global", f"macio-ide.dma-completion-delay-ns={dma_delay_ns}",
+        "-prom-env", "output-device=ttya",
+        "-g", "1024x768x15",
+        "-name", f"ClassicMac OS 9 Boot Benchmark ({dma_delay_ns} ns)",
+        "-audiodev", "none,id=snd0",
+        "-serial", f"file:{scratch / 'serial.log'}",
+        "-monitor", f"unix:{scratch / 'monitor.sock'},server=on,wait=off",
+        "-action", "reboot=shutdown",
+        "-drive",
+        f"file={disk},format=raw,media=disk"
+        + (f",cache={disk_cache}" if disk_cache else ""),
+        "-drive", "if=ide,index=3,media=cdrom,id=cd0,readonly=on",
+        "-drive", "if=ide,index=2,media=cdrom,id=tools0,readonly=on",
+        "-trace", f"enable=pmac_ide_completion,file={scratch / 'ide.trace'}",
+    ]
+    if minimal_devices:
+        command += ["-nic", "none"]
+    else:
+        command += [
+            "-blockdev",
+            f"driver=file,node-name=classicmac-tools-file,filename={tools},read-only=on",
+            "-blockdev",
+            "driver=raw,node-name=classicmac-tools,file=classicmac-tools-file,read-only=on",
+            "-device", "virtio-blk-pci,drive=classicmac-tools",
+            "-nic", "user,model=sungem",
+            "-device", f"loader,addr=0x4000000,file={loader}",
+            "-prom-env", "boot-command=init-program go",
+            "-device", "virtio-tablet-pci",
+        ]
+    if shared_folder is not None and not minimal_devices:
+        command += [
+            "-device", "virtio-9p-pci,fsdev=share0,mount_tag=Shared",
+            "-fsdev",
+            f"local,id=share0,security_model=none,path={shared_folder}",
+        ]
+    if icount is not None:
+        command += ["-icount", icount]
+    command += extra_qemu_args
+    return command
+
+
+def wait_for_monitor(path: Path, process: subprocess.Popen[bytes], timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"QEMU exited before creating its monitor ({process.returncode})")
+        if path.exists():
+            return
+        time.sleep(0.01)
+    raise RuntimeError("timed out waiting for the QEMU monitor")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("disk", type=Path, help="source Mac OS 9 raw disk image")
+    parser.add_argument(
+        "--qemu",
+        type=Path,
+        help="QEMU binary (defaults to vendor/qemu/build/qemu-system-ppc)",
+    )
+    parser.add_argument("--dma-delay-ns", type=int, default=1_000_000)
+    parser.add_argument("--ram-mb", type=int, default=512)
+    parser.add_argument(
+        "--disk-cache",
+        choices=("none", "directsync", "writeback", "unsafe"),
+        help="override QEMU's main-disk cache mode",
+    )
+    parser.add_argument("--accel", default="tcg,tb-size=512")
+    parser.add_argument("--cpu", default="7400")
+    parser.add_argument("--timeout", type=float, default=60.0)
+    parser.add_argument("--poll-interval", type=float, default=0.25)
+    parser.add_argument("--shared-folder", type=Path)
+    parser.add_argument("--icount")
+    parser.add_argument(
+        "--minimal-devices",
+        action="store_true",
+        help="omit ClassicMac Tools, networking, tablet, and folder sharing",
+    )
+    parser.add_argument(
+        "--extra-qemu-arg",
+        action="append",
+        default=[],
+        help="append one raw QEMU argument (use --extra-qemu-arg=-option)",
+    )
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument(
+        "--power-dialog",
+        action="store_true",
+        help="press the emulated ADB power key at Finder and save the result",
+    )
+    parser.add_argument(
+        "--graceful-shutdown",
+        action="store_true",
+        help="confirm the ADB power dialog and retain a clean boot volume",
+    )
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parent.parent
+    source = args.disk.expanduser().resolve()
+    if not source.is_file():
+        parser.error(f"disk image does not exist: {source}")
+    if args.dma_delay_ns < 0:
+        parser.error("--dma-delay-ns must be nonnegative")
+    if args.poll_interval <= 0 or args.timeout <= 0:
+        parser.error("timeout and poll interval must be positive")
+
+    source_before = source.stat()
+    qemu = (
+        args.qemu.expanduser().resolve()
+        if args.qemu
+        else root / "vendor/qemu/build/qemu-system-ppc"
+    )
+    if not qemu.is_file():
+        parser.error(f"QEMU binary does not exist: {qemu}")
+    scratch = Path(tempfile.mkdtemp(prefix="classicmac-os9-boot-", dir="/tmp"))
+    disk = scratch / "disk.img"
+    clone_disk(source, disk)
+    command = qemu_command(
+        root, qemu, disk, scratch, args.dma_delay_ns, args.ram_mb,
+        args.disk_cache, args.accel, args.cpu,
+        args.shared_folder.expanduser().resolve() if args.shared_folder else None,
+        args.icount,
+        args.extra_qemu_arg,
+        args.minimal_devices,
+    )
+    log = (scratch / "qemu.log").open("wb")
+    started = time.monotonic()
+    process = subprocess.Popen(command, cwd=root, stdout=log, stderr=subprocess.STDOUT)
+    finder_seconds: float | None = None
+    milestones: dict[str, float] = {}
+    failure: Exception | None = None
+    monitor_path = scratch / "monitor.sock"
+    frame_path = scratch / "frame.ppm"
+
+    try:
+        wait_for_monitor(monitor_path, process, 5.0)
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as monitor:
+            monitor.connect(str(monitor_path))
+            receive_until_prompt(monitor)
+            deadline = started + args.timeout
+            while time.monotonic() < deadline:
+                width, height, rgb = capture_frame(monitor, frame_path)
+                elapsed = time.monotonic() - started
+                checks = (
+                    ("welcome_seconds", welcome_is_visible(width, height, rgb)),
+                    ("desktop_seconds", desktop_is_visible(width, rgb)),
+                )
+                for name, reached in checks:
+                    if reached and name not in milestones:
+                        milestones[name] = elapsed
+                        shutil.copyfile(frame_path, scratch / f"{name}.ppm")
+                if finder_is_ready(width, rgb):
+                    finder_seconds = elapsed
+                    shutil.copyfile(frame_path, scratch / "finder.ppm")
+                    break
+                time.sleep(args.poll_interval)
+            if finder_seconds is not None and (
+                args.power_dialog or args.graceful_shutdown
+            ):
+                monitor.sendall(b"sendkey power\n")
+                receive_until_prompt(monitor)
+                time.sleep(1.0)
+                capture_frame(monitor, frame_path)
+                shutil.copyfile(frame_path, scratch / "power-dialog.ppm")
+            if finder_seconds is not None and args.graceful_shutdown:
+                monitor.sendall(b"sendkey ret\n")
+                receive_until_prompt(monitor)
+            else:
+                monitor.sendall(b"quit\n")
+    except Exception as error:  # Keep evidence and report after cleanup.
+        failure = error
+    finally:
+        try:
+            process.wait(timeout=15 if args.graceful_shutdown else 5)
+        except subprocess.TimeoutExpired:
+            process.terminate()
+            process.wait(timeout=5)
+        log.close()
+
+    source_after = source.stat()
+    if (source_before.st_size, source_before.st_mtime_ns) != (
+        source_after.st_size, source_after.st_mtime_ns
+    ):
+        raise RuntimeError("source disk metadata changed during the benchmark")
+    if failure is not None:
+        raise failure
+    if finder_seconds is None:
+        raise RuntimeError(f"Finder was not ready within {args.timeout:.1f} seconds")
+
+    trace_path = scratch / "ide.trace"
+    completions = 0
+    if trace_path.exists():
+        with trace_path.open("rb") as trace:
+            completions = sum(1 for _ in trace)
+    result = {
+        "finder_seconds": round(finder_seconds, 3),
+        "dma_delay_ns": args.dma_delay_ns,
+        "ide_dma_completions": completions,
+        "artificial_dma_seconds": round(completions * args.dma_delay_ns / 1e9, 3),
+        "ram_mb": args.ram_mb,
+        "disk_cache": args.disk_cache or "default",
+        "accel": args.accel,
+        "cpu": args.cpu,
+        "minimal_devices": args.minimal_devices,
+        "qemu": str(qemu),
+        "graceful_shutdown": args.graceful_shutdown,
+        "evidence": str(scratch),
+    }
+    result.update({name: round(value, 3) for name, value in milestones.items()})
+    print(json.dumps(result, sort_keys=True))
+    if not args.keep:
+        shutil.rmtree(scratch)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build-qemu.sh
+++ b/scripts/build-qemu.sh
@@ -68,6 +68,7 @@ PATCHED_FILES=(
   hw/nvram/mac_nvram.c
   accel/tcg/cputlb.c
   accel/tcg/tb-maint.c
+  target/ppc/mmu_helper.c
 )
 SCREAMER_DIR="$ROOT_DIR/screamer"
 PPCVID_DIR="$ROOT_DIR/ppcvid"
@@ -242,6 +243,12 @@ git -C "$QEMU_DIR" apply "$POWERMAC_DIR/classic-macos-8.patch" || die "Failed to
 # the small victim-TLB scan into hundreds of outlined helper calls.
 log "Installing TCG graphics-workload fast path"
 git -C "$QEMU_DIR" apply "$POWERMAC_DIR/tcg-graphics-fast-path.patch" || die "Failed to apply TCG graphics fast-path patch"
+# PowerPC BAT remaps cover contiguous guest-address ranges. Use QEMU's
+# range-aware TLB invalidation so a BAT update takes one lock and one bounded
+# scan instead of invalidating hundreds of pages independently. This keeps the
+# exact invalidation semantics while materially shortening Mac OS 9 startup.
+log "Installing PowerPC BAT range-invalidation fast path"
+git -C "$QEMU_DIR" apply "$POWERMAC_DIR/tcg-ppc-bat-range-flush.patch" || die "Failed to apply PowerPC BAT range-invalidation patch"
 # MacIO IDE/DBDMA completion timing: cached host I/O can otherwise complete
 # before classic Mac OS arms its synchronous wait, losing the wakeup and
 # freezing Mac OS 9.2.x Installer mid-copy. This also fixes the ordinary ATA


### PR DESCRIPTION
## What changed

- replace page-at-a-time PowerPC BAT TLB invalidation with QEMU's range-aware invalidation API
- make ClassicMac's Shut Down action invoke Mac OS's native ADB power dialog, with a 15-second forced-off fallback
- add a disposable-disk Mac OS 9 boot benchmark
- document measured boot results and an optional emulator-specific Extension Manager profile

## Why

Profiling Mac OS 9.2 startup found BAT remapping dominated QEMU's named host-side samples because contiguous mappings were invalidated one 4 KiB page at a time. ClassicMac also previously terminated QEMU immediately, leaving HFS/HFS+ dirty and causing several seconds of recovery work on the next boot.

The universal Mac OS 9 install also loads drivers for hardware ClassicMac does not expose. Testing shows those extensions can be disabled, but the gain is modest, so this PR documents an optional profile instead of changing guest systems automatically.

## Impact

- controlled clean-volume mean to Finder: 28.82s → 26.78s (-7.1%)
- optional extension profile: 26.78s → 26.11s (-2.5% additional)
- tested dirty volume: 32.80s; cleanly unmounted equivalent: 26.23s
- normal app shutdown now leaves the guest volume clean, improving both boot time and disk safety

## Validation

- full QEMU rebuild from the pristine patch stack
- QEMU GXMetal realization tests passed
- 29/29 Swift tests passed
- benchmark script syntax validation and shell syntax validation passed
- Developer ID app bundle built successfully
- strict deep code-signature verification passed
- bundled Power Mac G4 QEMU reached Finder in 26.23s from the clean test image
